### PR TITLE
CSS concat + minify for Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,9 @@ module.exports = function (grunt) {
             componentsJsFiles: [
                 'components/**/*.js'
             ],
+            componentsCssFiles: [
+                'components/**/*.css'
+            ],
             examplesJsFiles: [
                 'examples/!(_dependencies)/**/*.js'
             ],
@@ -44,11 +47,31 @@ module.exports = function (grunt) {
             }
         },
 
+        concat_css: {
+            options: {},
+            all: {
+                src: ['<%= meta.componentsCssFiles %>'],
+                dest: 'dist/<%= pkg.name %>.css'
+            }
+        },
+
+        cssmin: {
+            dist: {
+                files: [{
+                    expand: true,
+                    cwd: 'dist/',
+                    src: ['<%= pkg.name %>.css'],
+                    dest: 'dist/',
+                    ext: '.min.css'
+                }]
+            }
+        },
+
         copy: {
             main: {
                 expand: true,
                 cwd: 'dist/',
-                src: '**',
+                src: ['**', '!*.css'],
                 dest: 'examples/_dependencies/js/',
                 flatten: true,
                 filter: 'isFile'
@@ -101,7 +124,7 @@ module.exports = function (grunt) {
 
     require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 
-    grunt.registerTask('build', ['concat:dist', 'uglify:dist', 'copy:main']);
+    grunt.registerTask('build', ['concat:dist', 'uglify:dist', 'concat_css:all', 'cssmin:dist', 'copy:main']);
     grunt.registerTask('check:failOnError', ['jshint:failOnError', 'jscs:failOnError']);
     grunt.registerTask('check:warnOnly', ['jshint:warnOnly', 'jscs:warnOnly']);
     grunt.registerTask('check', ['check:failOnError']);

--- a/components/series/series.css
+++ b/components/series/series.css
@@ -1,0 +1,7 @@
+.ohlc-series .bar .up-day { stroke: #6c0; }
+.ohlc-series .bar .down-day { stroke: #c60; }
+.ohlc-series .bar .static-day { stroke: #000; }
+
+.ohlc-series .up-days { stroke: #6c0; }
+.ohlc-series .down-days { stroke: #c60; }
+.ohlc-series .bar .static-days { stroke: #000; }

--- a/dist/d3-financial-components.css
+++ b/dist/d3-financial-components.css
@@ -1,0 +1,7 @@
+.ohlc-series .bar .up-day { stroke: #6c0; }
+.ohlc-series .bar .down-day { stroke: #c60; }
+.ohlc-series .bar .static-day { stroke: #000; }
+
+.ohlc-series .up-days { stroke: #6c0; }
+.ohlc-series .down-days { stroke: #c60; }
+.ohlc-series .bar .static-days { stroke: #000; }

--- a/dist/d3-financial-components.min.css
+++ b/dist/d3-financial-components.min.css
@@ -1,0 +1,1 @@
+.ohlc-series .bar .up-day{stroke:#6c0}.ohlc-series .bar .down-day{stroke:#c60}.ohlc-series .bar .static-day{stroke:#000}.ohlc-series .up-days{stroke:#6c0}.ohlc-series .down-days{stroke:#c60}.ohlc-series .bar .static-days{stroke:#000}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-contrib-uglify": "^0.6.0"
+    "grunt-contrib-uglify": "^0.6.0",
+    "grunt-concat-css": "^0.3.1",
+    "grunt-contrib-cssmin": "^0.10.0"
   }
 }


### PR DESCRIPTION
For #76 

Concatenates and minifies CSS files in component folders into the dist folder. 
They're not copied to any examples folder at the moment.
Only has CSS for OHLC series for now.
