### PR TITLE
Added accessor methods to chartLayout

### DIFF
--- a/components/utilities/chartLayout.js
+++ b/components/utilities/chartLayout.js
@@ -48,6 +48,7 @@
 
                 // Create group for the chart
                 var chart =  svg.append('g')
+                    .attr('class', 'chartArea')
                     .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
 
                 // Clipping path
@@ -123,6 +124,20 @@
             return innerHeight;
         };
 
+        chartLayout.getSVG = function(setupArea) {
+            return setupArea.select("svg");
+        };
+
+        chartLayout.getChartArea = function(setupArea) {
+            return chartLayout.getSVG(setupArea).select(".chartArea");
+        };
+
+        chartLayout.getPlotArea = function(setupArea) {
+            return chartLayout.getSVG(setupArea).select(".plotArea");
+        };
+
         return chartLayout;
     };
+
+    
 }(d3, fc));


### PR DESCRIPTION
The accessors means that we don't have to expose the structure
I've also added a class to the chartArea, having a 'g' selector felt a bit dangerous!

The layout is now used as follows:

```
var chartLayout = fc.utilities.chartLayout();

var setupArea = d3.select('#financial-chart')
    .call(chartLayout);

var plotArea = chartLayout.getPlotArea(setupArea)
```

If people are happy with this, I'll add documentation before merge. Let me know what you think @jleft 
