### PR TITLE
Add Travis (Continuous Integration)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "0.10" # latest stable release
+  - "0.11" # latest development release, may be unstable
+before_install: npm install -g grunt-cli
+install: npm install
+matrix:
+  fast_finish: true
+  allow_failures:
+  - node_js: "0.11"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,7 +114,7 @@ module.exports = function (grunt) {
         },
 
         clean: {
-            doc: ["doc"]
+            doc: ['doc']
         }
     });
 
@@ -123,7 +123,9 @@ module.exports = function (grunt) {
     grunt.registerTask('check:failOnError', ['jshint:failOnError', 'jscs:failOnError']);
     grunt.registerTask('check:warnOnly', ['jshint:warnOnly', 'jscs:warnOnly']);
     grunt.registerTask('check', ['check:failOnError']);
-    grunt.registerTask('build', ['jshint:failOnError', 'jscs:failOnError', 'concat:dist', 'uglify:dist', 'concat_css:all', 'cssmin:dist']);
+    grunt.registerTask('build', ['check', 'concat:dist', 'uglify:dist', 'concat_css:all', 'cssmin:dist']);
     grunt.registerTask('dev', ['build', 'watch']);
-    grunt.registerTask('doc', ['clean:doc', 'jsdoc'])
+    grunt.registerTask('doc', ['clean:doc', 'jsdoc']);
+    grunt.registerTask('ci', ['default']);
+    grunt.registerTask('default', ['build', 'doc']);
 };

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# D3 Financial Components
+# D3 Financial Components [![Build Status](https://travis-ci.org/ScottLogic/d3-financial-components.svg?branch=master)](https://travis-ci.org/ScottLogic/d3-financial-components)
 
 We are building a set of re-usable [D3](http://d3js.org) components that make it simple to create complex financial charts.
 

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-jsdoc": "^0.5.7",
     "grunt-contrib-clean": "^0.6.0"
+  },
+  "scripts": {
+    "test": "grunt ci"
   }
 }


### PR DESCRIPTION
Travis will still need to be activated on their site for this to function, but I've added, what I think is a, reasonable configuration.

It'll run the grunt build and doc tasks on the latest stable release and the latest development release of node. The build on the development release is allowed to fail and the overall build will still pass. (Not sure if it's worth building on previous versions of node?)

If we're happy with this, I can add the AppVeyor (Windows) config too.
