### PR TITLE
Add series element width function for sizing candlestick/ohlc bars.

### DIFF
--- a/components/series/candlestick.js
+++ b/components/series/candlestick.js
@@ -11,7 +11,7 @@
             yLow = fc.utilities.valueAccessor('low'),
             yClose = fc.utilities.valueAccessor('close');
 
-        var rectangleWidth = 5;
+        var rectangleWidth = fc.utilities.seriesElementWidth(d3.time.day, 0.5);
 
         var isUpDay = function(d) {
             return yClose(d) > yOpen(d);
@@ -55,12 +55,12 @@
             rect.enter().append('rect');
 
             rect.attr('x', function(d) {
-                return xScale(d.date) - (rectangleWidth / 2.0);
+                return xScale(d.date) - (rectangleWidth(xScale) / 2.0);
             })
                 .attr('y', function(d) {
                     return isUpDay(d) ? yScale(yClose(d)) : yScale(yOpen(d));
                 })
-                .attr('width', rectangleWidth)
+                .attr('width', rectangleWidth(xScale))
                 .attr('height', function(d) {
                     return isUpDay(d) ?
                         yScale(yOpen(d)) - yScale(yClose(d)) :

--- a/components/series/ohlc.js
+++ b/components/series/ohlc.js
@@ -6,7 +6,7 @@
         // Configurable attributes
         var xScale = d3.time.scale(),
             yScale = d3.scale.linear(),
-            tickWidth = 5;
+            tickWidth = fc.utilities.seriesElementWidth(d3.time.day, 0.35);
 
         var yOpen = fc.utilities.valueAccessor('open'),
             yHigh = fc.utilities.valueAccessor('high'),
@@ -56,10 +56,11 @@
 
         // Path drawing
         var makeBarPath = function(d) {
-            var moveToLow = 'M' + date(d) + ',' + low(d),
+            var width = tickWidth(xScale),
+                moveToLow = 'M' + date(d) + ',' + low(d),
                 verticalToHigh = 'V' + high(d),
-                openTick = 'M' + date(d) + ',' + open(d) + 'h' + (-tickWidth),
-                closeTick = 'M' + date(d) + ',' + close(d) + 'h' + tickWidth;
+                openTick = 'M' + date(d) + ',' + open(d) + 'h' + (-width),
+                closeTick = 'M' + date(d) + ',' + close(d) + 'h' + width;
             return moveToLow + verticalToHigh + openTick + closeTick;
         };
 
@@ -126,7 +127,7 @@
 
                 bars.select('.high-low-line').attr({x1: date, y1: low, x2: date, y2: high});
                 bars.select('.open-tick').attr({
-                    x1: function(d) { return date(d) - tickWidth; },
+                    x1: function(d) { return date(d) - tickWidth(xScale); },
                     y1: open,
                     x2: date,
                     y2: open
@@ -134,7 +135,7 @@
                 bars.select('.close-tick').attr({
                     x1: date,
                     y1: close,
-                    x2: function(d) { return date(d) + tickWidth; },
+                    x2: function(d) { return date(d) + tickWidth(xScale); },
                     y2: close
                 });
 

--- a/components/utilities/seriesElementWidth.js
+++ b/components/utilities/seriesElementWidth.js
@@ -1,0 +1,20 @@
+(function(d3, fc) {
+    'use strict';
+
+    fc.utilities.seriesElementWidth = function(timeInterval, units) {
+        // Given a time scale, return the width of a number of timeInterval units.
+        return function(scale) {
+            var point, left, right, difference;
+
+            point = scale.domain()[0];
+            left = timeInterval.floor(point);
+            right = timeInterval.ceil(point);
+
+            if (left.getTime() === right.getTime()) {
+                right = timeInterval.offset(point, 1);
+            }
+            difference = Math.abs(scale(left) - scale(right));
+            return difference * units;
+        };
+    };
+}(d3, fc));


### PR DESCRIPTION
For #122 

This PR makes the ohlc and candlestick tick/bar widths functions instead of numbers, and provides a default called seriesElementWidth.

The idea of seriesElementWidth is, given a scale, work out how wide a d3 time interval (https://github.com/mbostock/d3/wiki/Time-Intervals) is on that scale. For example, a width of half a day is

``` javascript
fc.utilities.seriesElementWidth(d3.time.day, 0.5)(xScale)
```

This function assumes the scale returns Date objects for the domain, so it's not working with datetime scale. #166.
