### PR TITLE
extents function added to the fc namespace.

### DIFF
--- a/components/fc.js
+++ b/components/fc.js
@@ -31,8 +31,8 @@ window.fc = {
     utilities: {},
 
     /**
-     * The extents function uses the D3 extent() function calculate a domain from the data
-     * passed to it, specifically with multiple arrays of objects.
+     * The extents function mirrors the D3 extent() function. It calculates a domain from
+     * the data supplied, specifically arrays of arrays of objects.
      *
      * @namespace fc
      */

--- a/components/scale/dateTime.js
+++ b/components/scale/dateTime.js
@@ -87,40 +87,6 @@
         };
 
         /**
-        * Used to set or get the domain for this scale from a data set. The domain is the range of real world
-        * values denoted by this scale (Max. and Min.).
-        *
-        * @memberof fc.scale.dateTime
-        * @method domainFromValues
-        * @param {array} data the data set used to evaluate Min and Max values.
-        * @param {array} fields the fields within the data set used to evaluate Min and Max values.
-        * @returns the current domain if no arguments are passed.
-        */
-        scale.domainFromValues = function(data, fields) {
-
-            if (!arguments.length) {
-                return scale.domain();
-            } else {
-                var mins = [],
-                    maxs = [],
-                    fieldIndex = 0,
-                    getField = function(d) { return d[fields[fieldIndex]].getTime(); };
-
-                for (fieldIndex = 0; fieldIndex < fields.length; fieldIndex++) {
-                    mins.push(d3.min(data, getField));
-                    maxs.push(d3.max(data, getField));
-                }
-
-                scale.domain([
-                    new Date(d3.min(mins, function(d) { return d; })),
-                    new Date(d3.max(maxs, function(d) { return d; }))
-                ]);
-            }
-
-            return scale;
-        };
-
-        /**
         * Used to scale a value from pixel space to domain space. This function is the inverse of
         * the `scale` function.
         *

--- a/components/scale/linear.js
+++ b/components/scale/linear.js
@@ -66,49 +66,6 @@
         };
 
         /**
-        * Used to set or get the domain for this scale from a data set. The domain is the range of real world
-        * values denoted by this scale (Max. and Min.).
-        *
-        * @memberof fc.scale.linear
-        * @method domainFromValues
-
-        * @param {array} data the data set used to evaluate Min and Max values.
-        * @param {array} fields the properties of the objects within the data set used to evaluate Min and Max
-        * values.
-        * @param {number} [marginPercentage = 0.05] a margin, expressed as a percentage, that is applied to the domain
-        * range.
-        * @returns the current domain if no arguments are passed.
-        */
-        scale.domainFromValues = function(data, fields, marginPercentage) {
-
-            marginPercentage = typeof marginPercentage !== 'undefined' ? marginPercentage : 0.05;
-
-            if (!arguments.length) {
-                return scale.domain();
-            } else {
-                var mins = [],
-                    maxs = [],
-                    fieldIndex = 0,
-                    getField = function(d) { return d[fields[fieldIndex]]; };
-
-                for (fieldIndex = 0; fieldIndex < fields.length; fieldIndex++) {
-                    mins.push(d3.min(data, getField));
-                    maxs.push(d3.max(data, getField));
-                }
-
-                var min = d3.min(mins, function(d) { return d; }),
-                    max = d3.max(maxs, function(d) { return d; });
-
-                scale.domain([
-                    min - ((max - min) * marginPercentage),
-                    max + ((max - min) * marginPercentage)
-                ]);
-            }
-
-            return scale;
-        };
-
-        /**
         * Used to get an array of tick mark locations which can be used to display labels and
         * tick marks on the associated axis.
         *


### PR DESCRIPTION
This function is similar to d3.extents but takes 2 arguments the data and the field names.
- Data can be an array of data arrays or a single data array
- Fields can be an array of fields or a single field name

The function returns an array of two values denoting min and max.
