### PR TITLE
Fixes #420 - dataJoin attrs accepts key/value params as well as an object

### DIFF
--- a/src/util/dataJoin.js
+++ b/src/util/dataJoin.js
@@ -90,7 +90,16 @@
             if (!arguments.length) {
                 return attrs;
             }
-            attrs = x;
+
+            if (arguments.length === 1) {
+                attrs = arguments[0];
+            } else if (arguments.length === 2) {
+                var key = arguments[0];
+                var value = arguments[1];
+
+                attrs[key] = value;
+            }
+
             return dataJoin;
         };
         dataJoin.key = function(x) {

--- a/tests/util/dataJoinSpec.js
+++ b/tests/util/dataJoinSpec.js
@@ -1,0 +1,64 @@
+(function(d3, fc) {
+    'use strict';
+
+    describe('fc.util.dataJoin', function() {
+
+        describe('attrs', function() {
+
+            it('should replace attributes when object is provided', function() {
+                var attrs = {key: 'value'};
+
+                var observedAttrs = fc.util.dataJoin()
+                    .attrs(attrs)
+                    .attrs();
+
+                expect(observedAttrs).toEqual(attrs);
+            });
+
+            it('should add attributes when key value is provided', function() {
+                var key = 'key';
+                var value = 'value';
+
+                var observedAttrs = fc.util.dataJoin()
+                    .attrs(key, value)
+                    .attrs();
+
+                var expected = {};
+                expected[key] = value;
+                expect(observedAttrs).toEqual(expected);
+            });
+
+            it('should replace attributes when key value is provided', function() {
+                var key = 'key';
+                var value = 'newValue';
+
+                var observedAttrs = fc.util.dataJoin()
+                    .attrs(key, 'originalValue')
+                    .attrs(key, value)
+                    .attrs();
+
+                var expected = {};
+                expected[key] = value;
+                expect(observedAttrs).toEqual(expected);
+            });
+
+            it('should not alter other attributes than specified when key value is provided', function() {
+                var key = 'key';
+                var value = 'value';
+
+                var observedAttrs = fc.util.dataJoin()
+                    .attrs('anotherAttr', 'anotherValue')
+                    .attrs(key, value)
+                    .attrs();
+
+                var expected = {};
+                expected[key] = value;
+                expected.anotherAttr = 'anotherValue';
+                expect(observedAttrs).toEqual(expected);
+            });
+
+        });
+
+    });
+
+}(d3, fc));


### PR DESCRIPTION
#420 