### PR TITLE
Fix hamburger icon on examples page

### DIFF
--- a/site/src/examples/index.md
+++ b/site/src/examples/index.md
@@ -20,7 +20,7 @@ svg {
   width: 100%;
   height: 100%;
 }
-span {
+#low-barrel span {
   display:block;
   transform: rotate(90deg);
 }


### PR DESCRIPTION
On example page, hamburger icon is rotated 90 degrees.