### PR TITLE
re-instated class on multi series datajoin

### DIFF
--- a/src/series/multi.js
+++ b/src/series/multi.js
@@ -18,8 +18,9 @@
             decorate = fc.util.fn.noop;
 
         var dataJoin = fc.util.dataJoin()
-            .selector('g')
+            .selector('g.multi')
             .children(true)
+            .attrs({'class': 'multi'})
             .element('g')
             .key(function(d, i) {
                 // This function is invoked twice, the first pass is to pull the key


### PR DESCRIPTION
The crosshair is broken at the moment:

![screen shot 2015-07-12 at 19 22 30](https://cloud.githubusercontent.com/assets/1098110/8639235/6b42c52a-28cb-11e5-8bbe-1266b17ec01f.png)

This is because the multi series is placing one of the annotations within the trackball 'g' element which has a translate transform applied.

Re-instating the class on the multi series datajoin fixes this.

Fixes #486 