### PR TITLE
WIP: Adds grouped series

### DIFF
--- a/src/series/group.js
+++ b/src/series/group.js
@@ -1,0 +1,117 @@
+(function(d3, fc) {
+    'use strict';
+
+    fc.series.group = function() {
+
+        var decorate = fc.util.fn.noop,
+            xScale = d3.scale.linear(),
+            yScale = d3.scale.linear(),
+            xValue = function(d, i) { return d.x; },
+            groupValue = function(d, i) { return d.group;},
+            subScale = d3.scale.ordinal(),
+            subSeries = fc.series.bar(),
+            groupSize = fc.util.fractionalBarWidth(0.25);
+
+        var dataJoin = fc.util.dataJoin()
+            .selector('g.group')
+            .element('g')
+            .attrs({'class': 'group'});
+
+        var group = function(selection) {
+
+            selection.each(function(data, index) {
+
+                var dataByX = d3.nest()
+                    .key(xValue)
+                    .map(data);
+
+                var xValues = Object.keys(dataByX);
+
+                var width = groupSize(xValues.map(xScale)),
+                    halfWidth = width / 2;
+
+                var dataByGroup = d3.nest()
+                    .key(groupValue)
+                    .map(data);
+
+                var groupedValues = Object.keys(dataByGroup);
+
+                subScale.domain(groupedValues);
+
+                var g = dataJoin(this, groupedValues);
+
+                g.each(function(d, i) {
+
+                    subScale.rangePoints([-halfWidth, halfWidth]);
+
+                    var g = d3.select(this);
+
+                    g.attr('transform', 'translate(' + subScale(d) + ', 0)');
+
+                    subSeries.xScale(xScale)
+                        .yScale(yScale);
+
+                    d3.select(this)
+                        .datum(dataByGroup[d])
+                        .call(subSeries);
+
+                });
+
+                decorate(g, groupedValues, index);
+            });
+        };
+
+        group.decorate = function(x) {
+            if (!arguments.length) {
+                return decorate;
+            }
+            decorate = x;
+            return group;
+        };
+        group.xScale = function(x) {
+            if (!arguments.length) {
+                return xScale;
+            }
+            xScale = x;
+            return group;
+        };
+        group.yScale = function(x) {
+            if (!arguments.length) {
+                return yScale;
+            }
+            yScale = x;
+            return group;
+        };
+        group.xValue = function(x) {
+            if (!arguments.length) {
+                return xValue;
+            }
+            xValue = x;
+            return group;
+        };
+        group.groupValue = function(x) {
+            if (!arguments.length) {
+                return groupValue;
+            }
+            groupValue = x;
+            return group;
+        };
+        group.subSeries = function(x) {
+            if (!arguments.length) {
+                return subSeries;
+            }
+            subSeries = x;
+            return group;
+        };
+        group.groupSize = function(x) {
+            if (!arguments.length) {
+                return groupSize;
+            }
+            groupSize = d3.functor(x);
+            return group;
+        };
+
+        return group;
+
+    };
+}(d3, fc));

--- a/src/series/group.js
+++ b/src/series/group.js
@@ -8,9 +8,8 @@
             yScale = d3.scale.linear(),
             xValue = function(d, i) { return d.x; },
             groupValue = function(d, i) { return d.group;},
-            subScale = d3.scale.ordinal(),
-            subSeries = fc.series.bar(),
-            groupSize = fc.util.fractionalBarWidth(0.25);
+            offset = fc.util.fractionalGroupOffset(0.25),
+            subSeries = fc.series.bar();
 
         var dataJoin = fc.util.dataJoin()
             .selector('g.group')
@@ -26,9 +25,7 @@
                     .map(data);
 
                 var xValues = Object.keys(dataByX);
-
-                var width = groupSize(xValues.map(xScale)),
-                    halfWidth = width / 2;
+                var xPixels = xValues.map(xScale);
 
                 var dataByGroup = d3.nest()
                     .key(groupValue)
@@ -36,17 +33,13 @@
 
                 var groupedValues = Object.keys(dataByGroup);
 
-                subScale.domain(groupedValues);
-
                 var g = dataJoin(this, groupedValues);
 
                 g.each(function(d, i) {
 
-                    subScale.rangePoints([-halfWidth, halfWidth]);
-
                     var g = d3.select(this);
 
-                    g.attr('transform', 'translate(' + subScale(d) + ', 0)');
+                    g.attr('transform', 'translate(' + offset(d, i, groupedValues, xPixels) + ', 0)');
 
                     subSeries.xScale(xScale)
                         .yScale(yScale);
@@ -103,11 +96,11 @@
             subSeries = x;
             return group;
         };
-        group.groupSize = function(x) {
+        group.offset = function(x) {
             if (!arguments.length) {
-                return groupSize;
+                return offset;
             }
-            groupSize = d3.functor(x);
+            offset = d3.functor(x);
             return group;
         };
 

--- a/src/util/fractionalGroupOffset.js
+++ b/src/util/fractionalGroupOffset.js
@@ -1,0 +1,22 @@
+(function(d3, fc) {
+    'use strict';
+
+    // The offset property of the various series takes a function which, a given group, with a given set of groups
+    // and an array of X values, returns a suitable offset. This function returns an offset that evenly spaces all given
+    // groups, with the available space, where the available space is equal to the smallest distance between
+    // neighbouring X values multiplied by the given factor.
+    fc.util.fractionalGroupOffset = function(fraction) {
+
+        var groupWidth = fc.util.fractionalBarWidth(fraction);
+        var subScale = d3.scale.ordinal();
+
+        return function(group, index, groups, xPixels) {
+            var groupSpan = groupWidth(xPixels);
+
+            subScale.domain(groups)
+                .rangePoints([-groupSpan / 2, groupSpan / 2]);
+
+            return subScale(group);
+        };
+    };
+}(d3, fc));

--- a/src/util/intervalGroupOffset.js
+++ b/src/util/intervalGroupOffset.js
@@ -1,0 +1,19 @@
+(function(d3, fc) {
+    'use strict';
+
+    // The offset property of the various series takes a function which, a given group, with a given set of groups
+    // and an array of X values, returns a suitable offset. This function returns an offset which offsets all groups
+    // evenly by the given (interval) centred around 0.
+    fc.util.intervalGroupOffset = function(interval) {
+        var subScale = d3.scale.ordinal();
+
+        return function(group, index, groups) {
+            var groupSpan = (groups.length - 1) * interval;
+
+            subScale.domain(groups)
+                .rangePoints([-groupSpan / 2, groupSpan / 2]);
+
+            return subScale(group);
+        };
+    };
+}(d3, fc));

--- a/visual-tests/src/test-fixtures/series/grouped-bar.hbs
+++ b/visual-tests/src/test-fixtures/series/grouped-bar.hbs
@@ -1,0 +1,10 @@
+---
+title: Grouped Bar
+description: "Demonstrates the grouped bar component."
+categories: series
+tags:
+- grouped, bar, ordinal
+testScripts:
+- grouped-bar.js
+---
+<div id="grouped-bar"></div>

--- a/visual-tests/src/test-fixtures/series/grouped-bar.js
+++ b/visual-tests/src/test-fixtures/series/grouped-bar.js
@@ -1,0 +1,113 @@
+(function(d3, fc) {
+    'use strict';
+
+    var data = [
+        {
+            size: 'small',
+            flavour: 'chocolate',
+            sales: 3
+        },
+        {
+            size: 'small',
+            flavour: 'vanilla',
+            sales: 12
+        },
+        {
+            size: 'medium',
+            flavour: 'chocolate',
+            sales: 16
+        },
+        {
+            size: 'medium',
+            flavour: 'vanilla',
+            sales: 2
+        },
+        {
+            size: 'large',
+            flavour: 'chocolate',
+            sales: 3
+        },
+        {
+            size: 'large',
+            flavour: 'vanilla',
+            sales: 18
+        },
+        {
+            size: 'extra-large',
+            flavour: 'vanilla',
+            sales: 20
+        },
+        {
+            size: 'extra-large',
+            flavour: 'chocolate',
+            sales: 120
+        }
+    ];
+
+    var width = 600,
+        height = 250,
+        axisHeight = 25,
+        plotHeight = height - axisHeight;
+
+    var chart = d3.select('#grouped-bar')
+        .append('svg')
+        .attr('width', width)
+        .attr('height', height);
+
+    var axisContainer = chart.append('g')
+        .classed('axis', true)
+        .attr('transform', 'translate(0, ' + (plotHeight) + ')');
+
+    var plotArea = chart.append('g')
+        .classed('plot-area', true)
+        .attr({
+            height: height - axisHeight,
+            width: width
+        });
+
+    function render(data) {
+
+        var flavourScale = d3.scale.ordinal()
+            .domain(['chocolate', 'vanilla'])
+            .rangePoints([0, width], 1);
+
+        var salesScale = d3.scale.linear()
+            .domain([0, 20])
+            .range([plotHeight, 0])
+            .nice();
+
+        var colorScale = d3.scale.category20();
+
+        var bar = fc.series.bar()
+            .xValue(function(d) { return d.flavour; })
+            .yValue(function(d) { return d.sales; })
+            .barWidth(20);
+
+        var cycle = fc.series.group()
+            .yScale(salesScale)
+            .xScale(flavourScale)
+            .subSeries(bar)
+            .xValue(function(d) { return d.flavour; })
+            .groupValue(function(d) { return d.size; })
+            .decorate(function(g) {
+                g.enter()
+                    .attr('fill', function(d, i) {
+                        return colorScale(i);
+                    });
+            });
+
+        plotArea.datum(data)
+            .call(cycle);
+
+        // Create the axes
+        var xAxis = d3.svg.axis()
+            .scale(flavourScale)
+            .orient('bottom');
+
+        // Add the axes to the chart
+        axisContainer.call(xAxis);
+    }
+
+    render(data);
+
+})(d3, fc);

--- a/visual-tests/src/test-fixtures/series/grouped-bar.js
+++ b/visual-tests/src/test-fixtures/series/grouped-bar.js
@@ -89,6 +89,7 @@
             .subSeries(bar)
             .xValue(function(d) { return d.flavour; })
             .groupValue(function(d) { return d.size; })
+            .offset(fc.util.intervalGroupOffset(20))
             .decorate(function(g) {
                 g.enter()
                     .attr('fill', function(d, i) {


### PR DESCRIPTION
This is an WIP of the grouped series. As you can see, it's very similar to the cycle series, but differs in that:
* It always uses an ordinal subScale as there is always a discrete number of series in a group.
* It uses the subScale to translate the group, rather than the xScale, and uses the xScale to plot the series, rather than the subScale.

This feels quite similar to the Cycle but I can't quite put my finger on how to factor out any commonality, or whether the Group series should be using the Cycle series via composition some how - but it's not that important right now.

Currently, the bar size, group spacing & bar spacing is a little hard, and it won't always render a sensible looking chart if you don't choose sensible numbers yourself. I was thinking of pulling the grouped series into its own name space fc.series.grouped.group & adding a fc.series.grouped.bar series.

This grouped.bar series would rebind a bar series' barWidth, and provide automatic group spacing, depending on the barWidth implementation provided.

To save the hassle of loading up the visual test to see the result - here's an image:
![screen shot 2015-07-15 at 17 20 32](https://cloud.githubusercontent.com/assets/3799225/8703583/dbad87c2-2b15-11e5-9cf5-eef83bce0aaf.png)
 