### PR TITLE
[WIP] A drop-in replacement for the D3 SVG axis

### DIFF
--- a/site/src/_config.yml
+++ b/site/src/_config.yml
@@ -1,4 +1,4 @@
-component-ids: [annotation, chart, series, indicator, scale, tool, layout, data]
+component-ids: [chart, series, indicator, scale, svg, annotation, tool, layout, data]
 
 components:
   annotation:
@@ -13,6 +13,8 @@ components:
     name: Scale
   tool:
     name: Tools
+  svg:
+    name: SVG
   layout:
     name: Layout
   data:

--- a/site/src/components/svg/axis.md
+++ b/site/src/components/svg/axis.md
@@ -1,0 +1,111 @@
+---
+layout: component
+title: Axis
+component: svg/axis.js
+tags:
+namespace: svg
+
+fixture-code: |
+  var width = $(elementId).width();
+
+  var linearScale = d3.scale.linear()
+    .domain([0, 140])
+    .range([0, width])
+    .nice();
+
+  var ordinalScale = d3.scale.ordinal()
+    .domain(['Carrots', 'Bananas', 'Sausages', 'Pickles', 'Aubergines', 'Artichokes', 'Spinach', 'Cuccumber'])
+    .rangePoints([0, width], 1);
+
+example-code-one: |
+  var axis = fc.svg.axis()
+    .scale(ordinalScale)
+    .decorate(function(s) {
+      s.enter().select('text')
+        .style('text-anchor', 'start')
+        .attr('transform', 'rotate(45 -10 10)');
+    });
+
+  d3.select('#example-one')
+    .call(axis);
+
+example-code-two: |
+  var axis = fc.svg.axis()
+    .scale(ordinalScale)
+    .decorate(function(s) {
+      s.enter().select('text')
+        .attr('transform', function(d, i) {
+          return 'translate(0, ' + (i % 2 === 0 ? 25 : 10) + ')';
+        });
+    });
+
+  d3.select('#example-two')
+    .call(axis);
+
+example-code-three: |
+  var axis = fc.svg.axis()
+    .scale(linearScale)
+    .decorate(function(s) {
+      s.enter()
+        .attr('fill', function(d) {
+          return d >= 100 ? 'red' : 'black';
+        });
+    });
+
+  d3.select('#example-three')
+    .call(axis);
+
+---
+
+<style type="text/css">
+  .tick text {
+    font-size: 13px;
+  } 
+</style>
+
+The d3fc axis is a drop-in replacement for the `d3.svg.axis` component, which implements the d3fc decorate pattern. As a result it is much easier to customise the construction of the axis.
+
+For example, the decorate pattern can be used to rotate the tick labels:
+
+```js
+{{{example-code-one}}}
+```
+
+<svg class="axis-container" id="example-one"></svg>
+<script type="text/javascript">
+(function() {
+  var elementId = '#example-one';
+  {{{fixture-code}}}
+  {{{example-code-one}}}
+}());
+</script>
+
+Or alternatively the tick index can be used to offset alternating labels:
+
+```js
+{{{example-code-two}}}
+```
+
+<svg class="axis-container" id="example-two"></svg>
+<script type="text/javascript">
+(function() {
+  var elementId = '#example-two';
+  {{{fixture-code}}}
+  {{{example-code-two}}}
+}());
+</script>
+
+In the example below, the value bound to each tick is used to colour values greater than or equal to 100:
+
+```js
+{{{example-code-three}}}
+```
+
+<svg class="axis-container" id="example-three"></svg>
+<script type="text/javascript">
+(function() {
+  var elementId = '#example-three';
+  {{{fixture-code}}}
+  {{{example-code-three}}}
+}());
+</script>

--- a/site/src/style/components.less
+++ b/site/src/style/components.less
@@ -37,7 +37,7 @@
 			}
 		}
 
-		.nav-stacked > li > a  {
+		.nav-stacked > li > a	{
 			padding: 0 0 0 15px;
 			font-size: @font-size-small;
 			text-transform: none;
@@ -45,11 +45,18 @@
 	}
 
 	.chart {
-	  	width: 100%;
-	  	>svg {
-			margin-left: auto;
-		  	margin-right: auto;
-			border: 1px solid #ccc;
-	  	}
+			width: 100%;
+			>svg {
+				margin-left: auto;
+				margin-right: auto;
+				border: 1px solid #ccc;
+			}
+	}
+
+	.axis-container {
+		width: 400px;
+		height: 70px;
+		margin: 15px;
+		overflow: visible;
 	}
 }

--- a/src/annotation/band.js
+++ b/src/annotation/band.js
@@ -3,27 +3,20 @@
 
     fc.annotation.band = function() {
 
-        // ordinal axes have a rangeExtent function, this adds any padding that
-        // was applied to the range. This functions returns the rangeExtent
-        // if present, or range otherwise
-        function range(scale) {
-            return scale.rangeExtent ? scale.rangeExtent() : scale.range();
-        }
-
         var xScale = d3.time.scale(),
             yScale = d3.scale.linear(),
             x0, x1, y0, y1,
             x0Scaled = function() {
-                return range(xScale)[0];
+                return fc.util.scale.range(xScale)[0];
             },
             x1Scaled = function() {
-                return range(xScale)[1];
+                return fc.util.scale.range(xScale)[1];
             },
             y0Scaled = function() {
-                return range(yScale)[0];
+                return fc.util.scale.range(yScale)[0];
             },
             y1Scaled = function() {
-                return range(yScale)[1];
+                return fc.util.scale.range(yScale)[1];
             },
             decorate = fc.util.fn.noop;
 

--- a/src/annotation/line.js
+++ b/src/annotation/line.js
@@ -48,14 +48,7 @@
                         throw new Error('Invalid orientation');
                 }
 
-                // ordinal axes have a rangeExtent function, this adds any padding that
-                // was applied to the range. This functions returns the rangeExtent
-                // if present, or range otherwise
-                function range(scale) {
-                    return scale.rangeExtent ? scale.rangeExtent() : scale.range();
-                }
-
-                var scaleRange = range(crossScale),
+                var scaleRange = fc.util.scale.range(crossScale),
                     // the transform that sets the 'origin' of the annotation
                     containerTransform = function(d) {
                         var transform = valueScale(value(d));

--- a/src/chart/linearTimeSeries.js
+++ b/src/chart/linearTimeSeries.js
@@ -7,10 +7,10 @@
         var plotArea = fc.series.line();
         var xScale = fc.scale.dateTime();
         var yScale = d3.scale.linear();
-        var xAxis = d3.svg.axis()
+        var xAxis = fc.svg.axis()
             .scale(xScale)
             .orient('bottom');
-        var yAxis = d3.svg.axis()
+        var yAxis = fc.svg.axis()
             .scale(yScale)
             .orient('left');
 

--- a/src/fc.css
+++ b/src/fc.css
@@ -8,17 +8,6 @@
   fill-opacity: 0;
 }
 
-/* Default Axis Styles */
-.axis .domain,
-.axis .tick line {
-  fill: none;
-  stroke-width: 1.0;
-  stroke: #bbb;
-}
-.axis text {
-  font: 10px sans-serif;
-}
-
 .background {
   stroke: #eee;
   fill: #fefefe;

--- a/src/series/axis.js
+++ b/src/series/axis.js
@@ -1,12 +1,12 @@
 (function(d3, fc) {
     'use strict';
 
-    // Adapts a d3.svg.axis for use as a series (i.e. accepts xScale/yScale). Only required when
+    // Adapts a fc.svg.axis for use as a series (i.e. accepts xScale/yScale). Only required when
     // you want an axis to appear in the middle of a chart e.g. as part of a cycle plot. Otherwise
-    // prefer using the d3.svg.axis directly.
+    // prefer using the fc.svg.axis directly.
     fc.series.axis = function() {
 
-        var axis = d3.svg.axis(),
+        var axis = fc.svg.axis(),
             baseline = d3.functor(0),
             decorate = fc.util.fn.noop,
             xScale = d3.time.scale(),

--- a/src/svg/axis.css
+++ b/src/svg/axis.css
@@ -1,0 +1,33 @@
+.axis .domain,
+.axis .tick line,
+.axis .tick path {
+  fill: none;
+  stroke-width: 1.0;
+  stroke: #bbb;
+}
+
+.axis text {
+  font: 10px sans-serif;
+}
+
+.axis .orient-bottom text,
+.axis .orient-top text {
+  text-anchor: middle;
+}
+
+.axis .orient-left text,
+.axis .orient-right text {
+  dominant-baseline: middle;
+}
+
+.axis .orient-left text {
+  text-anchor: end;
+}
+
+.axis .orient-right text {
+  text-anchor: start;
+}
+
+.axis .orient-bottom text {
+ dominant-baseline: hanging;
+}

--- a/src/svg/axis.css
+++ b/src/svg/axis.css
@@ -1,33 +1,33 @@
-.axis .domain,
-.axis .tick line,
-.axis .tick path {
+.domain,
+.tick line,
+.tick path {
   fill: none;
   stroke-width: 1.0;
   stroke: #bbb;
 }
 
-.axis text {
+.tick text {
   font: 10px sans-serif;
 }
 
-.axis .orient-bottom text,
-.axis .orient-top text {
+.tick.orient-bottom text,
+.tick.orient-top text {
   text-anchor: middle;
 }
 
-.axis .orient-left text,
-.axis .orient-right text {
+.tick.orient-left text,
+.tick.orient-right text {
   dominant-baseline: middle;
 }
 
-.axis .orient-left text {
+.tick.orient-left text {
   text-anchor: end;
 }
 
-.axis .orient-right text {
+.tick.orient-right text {
   text-anchor: start;
 }
 
-.axis .orient-bottom text {
- dominant-baseline: hanging;
+.tick.orient-bottom text {
+  dominant-baseline: hanging;
 }

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -56,6 +56,10 @@
             return orient === 'left' || orient === 'right';
         }
 
+        function tryApply(fn, defaultVal) {
+            return scale[fn] ? scale[fn].apply(scale, tickArguments) : defaultVal;
+        }
+
         var axis = function(selection) {
 
             selection.each(function(data, index) {
@@ -63,10 +67,6 @@
                 // Stash a snapshot of the new scale, and retrieve the old snapshot.
                 var scaleOld = this.__chart__ || scale;
                 this.__chart__ = scale.copy();
-
-                function tryApply(fn, defaultVal) {
-                    return scale[fn] ? scale[fn].apply(scale, tickArguments) : defaultVal;
-                }
 
                 var ticksArray = tickValues == null ? tryApply('ticks', scale.domain()) : tickValues;
                 var tickFormatter = tickFormat == null ? tryApply('tickFormat', fc.util.fn.identity) : tickFormat;
@@ -83,7 +83,7 @@
                     ]);
 
                 var domainLine = domainPathDataJoin(container, [data]);
-                d3.transition(domainLine)
+                domainLine
                     .attr('d', svgDomainLine(domainPathData));
 
                 // datajoin and construct the ticks / label

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -204,6 +204,14 @@
             return axis;
         };
 
+        axis.decorate = function(x) {
+            if (!arguments.length) {
+                return decorate;
+            }
+            decorate = x;
+            return axis;
+        };
+
         return axis;
 
     };

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -1,0 +1,211 @@
+(function(d3, fc) {
+    'use strict';
+
+    // A drop-in replacement for the D3 axis, supporting the decorate pattern.
+    fc.svg.axis = function() {
+
+        var scale = d3.scale.identity(),
+              decorate = fc.util.fn.noop,
+              orient = 'bottom',
+              tickArguments = [10],
+              tickValues = null,
+              tickFormat = null,
+              outerTickSize = 6,
+              innerTickSize = 6,
+              tickPadding = 3,
+              svgDomainLine = d3.svg.line();
+
+        var dataJoin = fc.util.dataJoin()
+            .selector('g.tick')
+            .element('g')
+            .key(fc.util.fn.identity)
+            .attrs({'class': 'tick'});
+
+        // returns a function that creates a translation based on
+        // the bound data
+        function containerTranslate(s, trans) {
+            return function(d) {
+                return trans(s(d), 0);
+            };
+        }
+
+        function translate(x, y) {
+            return 'translate(' + x + ', ' + y + ')';
+        }
+
+        function translateTransposed(x, y) {
+            return 'translate(' + y + ', ' + x + ')';
+        }
+
+        function transposeArray(arr) {
+            return arr.map(function(d) {
+                return [d[1], d[0]];
+            });
+        }
+
+        function isVertical() {
+            return orient === 'left' || orient === 'right';
+        }
+
+        var axis = function(selection) {
+
+            selection.each(function(data, index) {
+
+                // Stash a snapshot of the new scale, and retrieve the old snapshot.
+                var scaleOld = this.__chart__ || scale;
+                this.__chart__ = scale.copy();
+
+                function tryApply(fn, defaultVal) {
+                    return scale[fn] ? scale[fn].apply(scale, tickArguments) : defaultVal;
+                }
+
+                var ticksArray = tickValues == null ? tryApply('ticks', scale.domain()) : tickValues;
+                var tickFormatter = tickFormat == null ? tryApply('tickFormat', fc.util.fn.identity) : tickFormat;
+
+                // orientation logic
+                var sign = orient === 'bottom' || orient === 'right' ? 1 : -1;
+                var pathTranspose = isVertical() ? transposeArray : fc.util.fn.identity;
+                var transform = isVertical() ? translateTransposed : translate;
+
+                var container = d3.select(this);
+
+                // add the domain line
+                var range = fc.util.scale.range(scale);
+                var domainPathData = pathTranspose([
+                      [range[0], sign * outerTickSize],
+                      [range[0], 0],
+                      [range[1], 0],
+                      [range[1], sign * outerTickSize]
+                    ]);
+
+                var domainLine = container.selectAll('path.domain')
+                    .data([data]);
+
+                domainLine.enter()
+                    .append('path')
+                    .classed('domain', true);
+
+                d3.transition(domainLine)
+                    .attr('d', svgDomainLine(domainPathData));
+
+                // datajoin and construct the ticks / label
+                dataJoin.attrs({
+                    'class': 'tick',
+                    // set the initial tick position based on the previous scale
+                    // in order to get the correct enter transition - however, for ordinal
+                    // scales the tick will not exist on the old scale, so use the current position
+                    'transform': containerTranslate(fc.util.scale.isOrdinal(scale) ? scale : scaleOld, transform)
+                });
+
+                var g = dataJoin(container, ticksArray);
+
+                // enter
+                var labelOffset = sign * (innerTickSize + tickPadding);
+                g.enter().classed('orient-' + orient, true);
+                g.enter().append('path');
+                g.enter()
+                    .append('text')
+                    .attr('transform', transform(0, labelOffset));
+
+                // update
+                g.attr('transform', containerTranslate(scale, transform));
+
+                g.selectAll('path')
+                    .attr('d', function(d) {
+                        return svgDomainLine(pathTranspose([
+                            [0, 0], [0, sign * innerTickSize]
+                        ]));
+                    });
+
+                g.selectAll('text')
+                   .attr('transform', transform(0, labelOffset))
+                   .text(tickFormatter);
+
+                // for non ordinal scales, exit by animating the tick to its new location
+                if (!fc.util.scale.isOrdinal(scale)) {
+                    g.exit()
+                        .attr('transform', containerTranslate(scale, transform));
+                }
+
+                decorate(g, data, index);
+            });
+        };
+
+        axis.scale = function(x) {
+            if (!arguments.length) {
+                return scale;
+            }
+            scale = x;
+            return axis;
+        };
+
+        axis.ticks = function(x) {
+            if (!arguments.length) {
+                return tickArguments;
+            }
+            tickArguments = arguments;
+            return axis;
+        };
+
+        axis.tickValues = function(x) {
+            if (!arguments.length) {
+                return tickValues;
+            }
+            tickValues = x;
+            return axis;
+        };
+
+        axis.tickFormat = function(x) {
+            if (!arguments.length) {
+                return tickFormat;
+            }
+            tickFormat = x;
+            return axis;
+        };
+
+        axis.tickSize = function(x) {
+            var n = arguments.length;
+            if (!n) {
+                return innerTickSize;
+            }
+            innerTickSize = Number(x);
+            outerTickSize = Number(arguments[n - 1]);
+            return axis;
+        };
+
+        axis.innerTickSize = function(x) {
+            if (!arguments.length) {
+                return innerTickSize;
+            }
+            innerTickSize = Number(x);
+            return axis;
+        };
+
+        axis.outerTickSize = function(x) {
+            if (!arguments.length) {
+                return outerTickSize;
+            }
+            outerTickSize = Number(x);
+            return axis;
+        };
+
+        axis.tickPadding = function(x) {
+            if (!arguments.length) {
+                return tickPadding;
+            }
+            tickPadding = x;
+            return axis;
+        };
+
+        axis.orient = function(x) {
+            if (!arguments.length) {
+                return orient;
+            }
+            orient = x;
+            return axis;
+        };
+
+        return axis;
+
+    };
+}(d3, fc));

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -88,7 +88,6 @@
 
                 // datajoin and construct the ticks / label
                 dataJoin.attrs({
-                    'class': 'tick',
                     // set the initial tick position based on the previous scale
                     // in order to get the correct enter transition - however, for ordinal
                     // scales the tick will not exist on the old scale, so use the current position
@@ -98,14 +97,16 @@
                 var g = dataJoin(container, ticksArray);
 
                 // enter
-                var labelOffset = sign * (innerTickSize + tickPadding);
-                g.enter().classed('orient-' + orient, true);
                 g.enter().append('path');
+
+                var labelOffset = sign * (innerTickSize + tickPadding);
                 g.enter()
                     .append('text')
                     .attr('transform', translate(0, labelOffset));
 
                 // update
+                g.attr('class', 'tick orient-' + orient);
+
                 g.attr('transform', containerTranslate(scale, translate));
 
                 g.selectAll('path')
@@ -119,7 +120,7 @@
                    .attr('transform', translate(0, labelOffset))
                    .text(tickFormatter);
 
-                // for non ordinal scales, exit by animating the tick to its new location
+                // exit - for non ordinal scales, exit by animating the tick to its new location
                 if (!fc.util.scale.isOrdinal(scale)) {
                     g.exit()
                         .attr('transform', containerTranslate(scale, translate));

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -21,6 +21,11 @@
             .key(fc.util.fn.identity)
             .attrs({'class': 'tick'});
 
+        var domainPathDataJoin = fc.util.dataJoin()
+            .selector('path.domain')
+            .element('path')
+            .attrs({'class': 'domain'});
+
         // returns a function that creates a translation based on
         // the bound data
         function containerTranslate(s, trans) {
@@ -78,13 +83,7 @@
                       [range[1], sign * outerTickSize]
                     ]);
 
-                var domainLine = container.selectAll('path.domain')
-                    .data([data]);
-
-                domainLine.enter()
-                    .append('path')
-                    .classed('domain', true);
-
+                var domainLine = domainPathDataJoin(container, [data]);
                 d3.transition(domainLine)
                     .attr('d', svgDomainLine(domainPathData));
 

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -35,17 +35,21 @@
         }
 
         function translate(x, y) {
-            return 'translate(' + x + ', ' + y + ')';
+            if (isVertical()) {
+                return 'translate(' + y + ', ' + x + ')';
+            } else {
+                return 'translate(' + x + ', ' + y + ')';
+            }
         }
 
-        function translateTransposed(x, y) {
-            return 'translate(' + y + ', ' + x + ')';
-        }
-
-        function transposeArray(arr) {
-            return arr.map(function(d) {
-                return [d[1], d[0]];
-            });
+        function pathTranspose(arr) {
+            if (isVertical()) {
+                return arr.map(function(d) {
+                    return [d[1], d[0]];
+                });
+            } else {
+                return arr;
+            }
         }
 
         function isVertical() {
@@ -66,12 +70,7 @@
 
                 var ticksArray = tickValues == null ? tryApply('ticks', scale.domain()) : tickValues;
                 var tickFormatter = tickFormat == null ? tryApply('tickFormat', fc.util.fn.identity) : tickFormat;
-
-                // orientation logic
                 var sign = orient === 'bottom' || orient === 'right' ? 1 : -1;
-                var pathTranspose = isVertical() ? transposeArray : fc.util.fn.identity;
-                var transform = isVertical() ? translateTransposed : translate;
-
                 var container = d3.select(this);
 
                 // add the domain line
@@ -93,7 +92,7 @@
                     // set the initial tick position based on the previous scale
                     // in order to get the correct enter transition - however, for ordinal
                     // scales the tick will not exist on the old scale, so use the current position
-                    'transform': containerTranslate(fc.util.scale.isOrdinal(scale) ? scale : scaleOld, transform)
+                    'transform': containerTranslate(fc.util.scale.isOrdinal(scale) ? scale : scaleOld, translate)
                 });
 
                 var g = dataJoin(container, ticksArray);
@@ -104,10 +103,10 @@
                 g.enter().append('path');
                 g.enter()
                     .append('text')
-                    .attr('transform', transform(0, labelOffset));
+                    .attr('transform', translate(0, labelOffset));
 
                 // update
-                g.attr('transform', containerTranslate(scale, transform));
+                g.attr('transform', containerTranslate(scale, translate));
 
                 g.selectAll('path')
                     .attr('d', function(d) {
@@ -117,13 +116,13 @@
                     });
 
                 g.selectAll('text')
-                   .attr('transform', transform(0, labelOffset))
+                   .attr('transform', translate(0, labelOffset))
                    .text(tickFormatter);
 
                 // for non ordinal scales, exit by animating the tick to its new location
                 if (!fc.util.scale.isOrdinal(scale)) {
                     g.exit()
-                        .attr('transform', containerTranslate(scale, transform));
+                        .attr('transform', containerTranslate(scale, translate));
                 }
 
                 decorate(g, data, index);

--- a/src/tool/crosshair.js
+++ b/src/tool/crosshair.js
@@ -29,19 +29,12 @@
             .value(x)
             .label(function(d) { return d.x; });
 
-        // ordinal axes have a rangeExtent function, this adds any padding that
-        // was applied to the range. This functions returns the rangeExtent
-        // if present, or range otherwise
-        function range(scale) {
-            return scale.rangeExtent ? scale.rangeExtent() : scale.range();
-        }
-
         // the line annotations used to render the crosshair are positioned using
         // screen coordinates. This function constructs a suitable scale for rendering
         // these annotations.
         function identityScale(scale) {
             return d3.scale.identity()
-                .range(range(scale));
+                .range(fc.util.scale.range(scale));
         }
 
 
@@ -63,10 +56,10 @@
                     .style('visibility', 'hidden');
 
                 container.select('rect')
-                    .attr('x', range(xScale)[0])
-                    .attr('y', range(yScale)[1])
-                    .attr('width', range(xScale)[1])
-                    .attr('height', range(yScale)[0]);
+                    .attr('x', fc.util.scale.range(xScale)[0])
+                    .attr('y', fc.util.scale.range(yScale)[1])
+                    .attr('width', fc.util.scale.range(xScale)[1])
+                    .attr('height', fc.util.scale.range(yScale)[0]);
 
                 var crosshair = dataJoin(container, data);
 

--- a/src/util/scale.js
+++ b/src/util/scale.js
@@ -6,11 +6,11 @@
         // was applied to the range. This functions returns the rangeExtent
         // if present, or range otherwise
         range: function(scale) {
-            return scale.rangeExtent ? scale.rangeExtent() : scale.range();
+            return fc.util.scale.isOrdinal(scale) ? scale.rangeExtent() : scale.range();
         },
 
         isOrdinal: function(scale) {
-            return scale.rangeBands;
+            return scale.rangeExtent;
         }
     };
 }(d3, fc));

--- a/src/util/scale.js
+++ b/src/util/scale.js
@@ -1,0 +1,16 @@
+(function(d3, fc) {
+    'use strict';
+
+    fc.util.scale = {
+        // ordinal axes have a rangeExtent function, this adds any padding that
+        // was applied to the range. This functions returns the rangeExtent
+        // if present, or range otherwise
+        range: function(scale) {
+            return scale.rangeExtent ? scale.rangeExtent() : scale.range();
+        },
+
+        isOrdinal: function(scale) {
+            return scale.rangeBands;
+        }
+    };
+}(d3, fc));

--- a/visual-tests/src/test-fixtures/functional/ordinalAxis.js
+++ b/visual-tests/src/test-fixtures/functional/ordinalAxis.js
@@ -30,7 +30,7 @@
         .range([height - axisHeight, 0]);
 
     // Create the axes
-    var xAxis = d3.svg.axis()
+    var xAxis = fc.svg.axis()
         .scale(xScale)
         .orient('bottom');
 

--- a/visual-tests/src/test-fixtures/scale/fc-time-d3-linear-hide-weekend.js
+++ b/visual-tests/src/test-fixtures/scale/fc-time-d3-linear-hide-weekend.js
@@ -18,7 +18,7 @@
         .range([0, width]);
 
     // Create the axes
-    var dateAxis = d3.svg.axis()
+    var dateAxis = fc.svg.axis()
         .scale(dateScale)
         .orient('bottom')
         .ticks(10);

--- a/visual-tests/src/test-fixtures/series/bar-transitions.js
+++ b/visual-tests/src/test-fixtures/series/bar-transitions.js
@@ -61,7 +61,6 @@
         .call(bar);
 
     var axisContainer = chart.append('g')
-        .attr('class', 'axis')
         .attr('transform', 'translate(0, ' + (yScale(0)) + ')');
 
     // Create the axis

--- a/visual-tests/src/test-fixtures/series/bar-transitions.js
+++ b/visual-tests/src/test-fixtures/series/bar-transitions.js
@@ -65,7 +65,7 @@
         .attr('transform', 'translate(0, ' + (yScale(0)) + ')');
 
     // Create the axis
-    var xAxis = d3.svg.axis()
+    var xAxis = fc.svg.axis()
         .scale(xScale)
         .orient('bottom');
 

--- a/visual-tests/src/test-fixtures/svg/axis.hbs
+++ b/visual-tests/src/test-fixtures/svg/axis.hbs
@@ -1,0 +1,12 @@
+---
+title: Axis
+description: "Demonstrates decoration and axis transitions"
+categories: svg
+tags:
+- axis
+- deocrate
+testScripts:
+- axis.js
+---
+
+<div id="axis"></div>

--- a/visual-tests/src/test-fixtures/svg/axis.js
+++ b/visual-tests/src/test-fixtures/svg/axis.js
@@ -19,7 +19,7 @@
     function render() {
         var scale = d3.scale.linear()
             .domain([0, tick % 2 === 0 ? 50 : 200])
-            .range([0, width])
+            .range([0, width - (tick % 2 === 0 ? 50 : 0)])
             .nice();
 
         var axis = fc.svg.axis()

--- a/visual-tests/src/test-fixtures/svg/axis.js
+++ b/visual-tests/src/test-fixtures/svg/axis.js
@@ -1,0 +1,38 @@
+(function(d3, fc) {
+    'use strict';
+
+    var width = 600, height = 250;
+
+    var svg = d3.select('#axis')
+        .append('svg')
+        .attr('width', width)
+        .attr('height', height)
+        .attr('style', 'margin: 20px; overflow: visible');
+
+    var tick = 0;
+
+    var c = d3.scale.category10();
+    var color = function(d, i) {
+        return c(i);
+    };
+
+    function render() {
+        var scale = d3.scale.linear()
+            .domain([0, tick % 2 === 0 ? 50 : 200])
+            .range([0, width])
+            .nice();
+
+        var axis = fc.svg.axis()
+            .scale(scale)
+            .decorate(function(sel) {
+                sel.attr('fill', color);
+                sel.select('path').style('stroke', color);
+            });
+
+        svg.transition().call(axis);
+
+        tick++;
+    }
+
+    setInterval(render, 2000);
+})(d3, fc);

--- a/visual-tests/src/test-fixtures/util/layout.js
+++ b/visual-tests/src/test-fixtures/util/layout.js
@@ -32,12 +32,12 @@
         .nice();
 
     // Create the axes
-    var dateAxis = d3.svg.axis()
+    var dateAxis = fc.svg.axis()
         .scale(dateScale)
         .orient('bottom')
         .ticks(5);
 
-    var priceAxis = d3.svg.axis()
+    var priceAxis = fc.svg.axis()
         .scale(priceScale)
         .orient('right')
         .ticks(5);


### PR DESCRIPTION
Fixes #466 

This is a drop-in replacement for the D3 scale, with the aim of making it conform to the decorate pattern (which I think is quite central to d3fc). The implementation differs from the D3 equivalent in a few ways:

 + Uses SVG `path` for the ticks rather than `line`, this makes the code simpler by using a 'transpose' function that can transpose an SVG path supporting vertical / horizontal axes
 + D3 does not ship with CSS, as a result the axis implementation 'manually' positions / styles the labels. This implementation has CSS making the label positioning a bit simpler.

I've also pulled out a few scale related utility functions.

One thing I want to debate is the axis structure and the impact it has on CSS. Currently we rely on the axis being added within a `g` with a class of `axis`. This feels a bit fragile. There are two options:

 1. The axis component adds a `g` with this class.
 2. The tick containers have additional classes added that allow us unambiguously target them with selectors, perhaps having a class of `axis tick orient-bottom`. 

I am not keen on (2) because it results in a lot of repeated information. My preference would be to pull the common information into a container `g` with a class of `axis orient-bottom`.

TODO (before merge)
 + [x] Add documentation
 + [x] Finalise the CSS

TODOs (from review feedback, duplicated from https://github.com/ScottLogic/d3fc/pull/503#issuecomment-125765180 so that they appear in the PR summary)
 + [x] use `fc.util.datajoin` to create the domain path
 + [x] try moving `isVertical()` into the helper functions to see if it results in simpler code
 + [x] ensure orientation changes function properly
 + [x] test and expose `decorate`
 + [x] be self-consistent regarding ordinal axis identification

Anyhow, any feedback or comments relating the CSS / axis structure would be welcome.