### PR TITLE
Updated strapline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # d3fc [![Build Status](https://travis-ci.org/ScottLogic/d3fc.svg?branch=master)](https://travis-ci.org/ScottLogic/d3fc)
 
-A collection of components that make it easy to build interactive financial charts with  [D3](http://d3js.org).
+A collection of components that make it easy to build interactive charts with D3.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d3fc",
   "version": "0.4.0",
-  "description": "A set of re-useable components for building financial charts with D3",
+  "description": "A collection of components that make it easy to build interactive charts with D3",
   "author": "Scott Logic",
   "dependencies": {
     "css-layout": "^0.0.2",


### PR DESCRIPTION
We had different straplines in various locations (GitHub project description, `package.json`, `README.md`) - this updates them all to match the website strapline which feels the most accurate at the moment.