### PR TITLE
series no longer key on xValue

### DIFF
--- a/src/series/area.js
+++ b/src/series/area.js
@@ -82,6 +82,9 @@
             return area;
         };
 
-        return d3.rebind(area, areaData, 'interpolate', 'tension');
+        d3.rebind(area, dataJoin, 'key');
+        d3.rebind(area, areaData, 'interpolate', 'tension');
+
+        return area;
     };
 }(d3, fc));

--- a/src/series/bar.js
+++ b/src/series/bar.js
@@ -27,7 +27,7 @@
                         xValue(d, i) !== undefined;
                 });
 
-                var g = dataJoin.key(xValue)(this, filteredData);
+                var g = dataJoin(this, filteredData);
 
                 var width = barWidth(filteredData.map(xValueScaled));
 
@@ -111,6 +111,8 @@
             barWidth = d3.functor(x);
             return bar;
         };
+
+        d3.rebind(bar, dataJoin, 'key');
 
         return bar;
     };

--- a/src/series/candlestick.js
+++ b/src/series/candlestick.js
@@ -24,7 +24,7 @@
 
             selection.each(function(data, index) {
 
-                var g = dataJoin.key(xValue)(this, data);
+                var g = dataJoin(this, data);
 
                 g.enter()
                     .append('path');
@@ -126,6 +126,8 @@
             barWidth = d3.functor(x);
             return candlestick;
         };
+
+        d3.rebind(candlestick, dataJoin, 'key');
 
         return candlestick;
 

--- a/src/series/cycle.js
+++ b/src/series/cycle.js
@@ -102,6 +102,8 @@
             return cycle;
         };
 
+        d3.rebind(cycle, dataJoin, 'key');
+
         return cycle;
 
     };

--- a/src/series/line.js
+++ b/src/series/line.js
@@ -72,6 +72,9 @@
             return line;
         };
 
-        return d3.rebind(line, lineData, 'interpolate', 'tension');
+        d3.rebind(line, dataJoin, 'key');
+        d3.rebind(line, lineData, 'interpolate', 'tension');
+
+        return line;
     };
 }(d3, fc));

--- a/src/series/ohlc.js
+++ b/src/series/ohlc.js
@@ -23,7 +23,7 @@
         var ohlc = function(selection) {
             selection.each(function(data, index) {
 
-                var g = dataJoin.key(xValue)(this, data);
+                var g = dataJoin(this, data);
 
                 g.enter()
                     .append('path');
@@ -124,6 +124,8 @@
             barWidth = d3.functor(x);
             return ohlc;
         };
+
+        d3.rebind(ohlc, dataJoin, 'key');
 
         return ohlc;
     };

--- a/src/series/point.js
+++ b/src/series/point.js
@@ -19,7 +19,7 @@
 
             selection.each(function(data, index) {
 
-                var g = dataJoin.key(xValue)(this, data);
+                var g = dataJoin(this, data);
 
                 g.enter()
                     .append('circle');
@@ -80,6 +80,8 @@
             radius = x;
             return point;
         };
+
+        d3.rebind(point, dataJoin, 'key');
 
         return point;
     };

--- a/tests/series/barSpec.js
+++ b/tests/series/barSpec.js
@@ -21,7 +21,7 @@
             container.datum(data)
                 .call(bar);
 
-            expect(xValueSpy.calls.count()).toEqual(data.length * 5);
+            expect(xValueSpy.calls.count()).toEqual(data.length * 4);
             this.utils.verifyAccessorCalls(xValueSpy, data);
 
 

--- a/tests/series/candlestickSpec.js
+++ b/tests/series/candlestickSpec.js
@@ -26,10 +26,10 @@
                 .call(candlestick);
 
             // the data join and the bar width calculations also invoke
-            // the x value accessor, therefore it is invoked three times
+            // the x value accessor, therefore it is invoked multiple times
             // for each data point
 
-            expect(xValueSpy.calls.count()).toEqual(data.length * 3);
+            expect(xValueSpy.calls.count()).toEqual(data.length * 2);
             this.utils.verifyAccessorCalls(xValueSpy, data);
 
             expect(yOpenValueSpy.calls.count()).toEqual(data.length);

--- a/tests/series/ohlcSpec.js
+++ b/tests/series/ohlcSpec.js
@@ -26,10 +26,10 @@
                 .call(ohlc);
 
             // the data join and the bar width calculations also invoke
-            // the x value accessor, therefore it is invoked three times
+            // the x value accessor, therefore it is invoked multiple times
             // for each data point
 
-            expect(xValueSpy.calls.count()).toEqual(data.length * 3);
+            expect(xValueSpy.calls.count()).toEqual(data.length * 2);
             this.utils.verifyAccessorCalls(xValueSpy, data);
 
             expect(yOpenValueSpy.calls.count()).toEqual(data.length);

--- a/tests/series/pointSpec.js
+++ b/tests/series/pointSpec.js
@@ -19,10 +19,7 @@
             container.datum(data)
                 .call(point);
 
-            // the data join also invokes
-            // the x value accessor, therefore it is invoked two times
-            // for each data point
-            expect(xValueSpy.calls.count()).toEqual(data.length * 2);
+            expect(xValueSpy.calls.count()).toEqual(data.length);
             this.utils.verifyAccessorCalls(xValueSpy, data);
 
             expect(yValueSpy.calls.count()).toEqual(data.length);

--- a/visual-tests/src/test-fixtures/series/bar-transitions.js
+++ b/visual-tests/src/test-fixtures/series/bar-transitions.js
@@ -42,8 +42,9 @@
 
     // Create the bar series
     var bar = fc.series.bar()
-        .xValue(function(d) { return d.name; })
         .yValue(function(d) { return d.age; })
+        .xValue(function(d) { return d.name; })
+        .key(function(d) { return d.name; })
         .xScale(xScale)
         .yScale(yScale)
         .decorate(function(sel) {


### PR DESCRIPTION
Series currently use the x-value for the data-join key, this prohibits them being used for any chart where multiple datapoints share the same x-value.

This PR changes the series to use the default, index-based, key and rebinds to expose it as a configurable property.

As a result, you can create plots like this GitHub punchcard:

![screen shot 2015-08-05 at 08 15 07](https://cloud.githubusercontent.com/assets/1098110/9080349/99701bfa-3b4a-11e5-974d-bc713cad43da.png)
