### PR TITLE
Fixes the Yahoo example

### DIFF
--- a/site/src/examples/yahoo-finance-chart/index.css
+++ b/site/src/examples/yahoo-finance-chart/index.css
@@ -24,7 +24,7 @@ path.ema {
   opacity: 0.7;
 }
 
-.plot-area {
+svg.plot-area {
   overflow: visible;
 }
 
@@ -80,4 +80,17 @@ path.ema {
 .crosshair .bottom-handle text {
   text-anchor: middle;
   dominant-baseline: central;
+}
+
+.tick.orient-bottom text {
+  text-anchor: start;
+  dominant-baseline: central;
+}
+
+.tick.orient-right text {
+  text-anchor: end;
+}
+
+td, th {
+  padding: 3px;
 }

--- a/site/src/examples/yahoo-finance-chart/index.js
+++ b/site/src/examples/yahoo-finance-chart/index.js
@@ -145,6 +145,19 @@ function renderChart(data) {
         .xTickSize(xAxisHeight)
         .xTicks(3);
 
+  // customise the axis
+  chart.xDecorate(function(sel) {
+    sel.enter()
+      .select('text')
+      .attr('transform', 'translate(3, ' + (xAxisHeight / 2) + ' )');
+  });
+
+  chart.yDecorate(function(sel) {
+    sel.enter()
+      .select('text')
+      .attr('transform', 'translate(' + (yAxisWidth - 1) + ', -6)');
+  });
+
   // create the line annotations
   var emaClose = fc.annotation.line()
     .value(function(d) { return d.exponentialMovingAverage; })
@@ -285,14 +298,4 @@ function renderChart(data) {
 
   // render the legend
   renderLegend(data[data.length - 1]);
-
-  // customise the D3 axis
-  d3.selectAll('.y-axis text')
-      .style('text-anchor', 'end')
-      .attr('transform', 'translate(-3, -8)');
-
-  d3.selectAll('.x-axis text')
-      .attr('dy', undefined)
-      .style({'text-anchor': 'start', 'dominant-baseline': 'central'})
-      .attr('transform', 'translate(3, -' + (xAxisHeight / 2 + 3) + ' )');
 }

--- a/src/chart/linearTimeSeries.js
+++ b/src/chart/linearTimeSeries.js
@@ -105,7 +105,8 @@
             xOuterTickSize: 'outerTickSize',
             xTickPadding: 'tickPadding',
             xTickFormat: 'tickFormat',
-            xOrient: 'orient'
+            xOrient: 'orient',
+            xDecorate: 'decorate'
         });
 
         fc.util.rebind(linearTimeSeries, yAxis, {
@@ -116,7 +117,8 @@
             yOuterTickSize: 'outerTickSize',
             yTickPadding: 'tickPadding',
             yTickFormat: 'tickFormat',
-            yOrient: 'orient'
+            yOrient: 'orient',
+            yDecorate: 'decorate'
         });
 
         linearTimeSeries.xScale = function() { return xScale; };

--- a/src/svg/bar.js
+++ b/src/svg/bar.js
@@ -41,7 +41,7 @@
                     // Draw the width
                     'h' + barWidth +
                     // Draw to the top
-                    'V' + barHeight +
+                    'v' + barHeight +
                     // Draw the width
                     'h' + -barWidth +
                     // Close the path

--- a/tests/annotation/bandSpec.js
+++ b/tests/annotation/bandSpec.js
@@ -24,7 +24,7 @@
                 .call(band);
 
             var path = element.children[0].children[0];
-            expect(path.getAttribute('d')).toEqual('M0,0h20V20h-20z');
+            expect(path.getAttribute('d')).toEqual('M0,0h20v20h-20z');
         });
 
         it('should support function properties', function() {
@@ -48,7 +48,7 @@
                 .call(band);
 
             var path = element.children[0].children[0];
-            expect(path.getAttribute('d')).toEqual('M4,12h4V4h-4z');
+            expect(path.getAttribute('d')).toEqual('M4,12h4v4h-4z');
         });
 
         it('should support literal properties via functors', function() {
@@ -72,7 +72,7 @@
                 .call(band);
 
             var path = element.children[0].children[0];
-            expect(path.getAttribute('d')).toEqual('M4,12h4V4h-4z');
+            expect(path.getAttribute('d')).toEqual('M4,12h4v4h-4z');
         });
 
         it('should invoke coordinate functions with correct parameters and context', function() {


### PR DESCRIPTION
 + axis styling moved to use decorate
 + linearTimeSeries updated to expose the decorate function for axes
 + bar svg was incorrectly using 'V' (absolute) rather than 'v' (relative), this took a while to track down!