### PR TITLE
Add simple resize handles to navigator extent in Low Barrel example

### DIFF
--- a/site/src/examples/low-barrel/index.css
+++ b/site/src/examples/low-barrel/index.css
@@ -41,6 +41,11 @@ rect.extent {
     stroke: #C0C0C0;
     stroke-width: 1px;
 }
+.resize>rect {
+    fill: #435862;
+    stroke: #C0C0C0;
+    stroke-width: 1px;
+}
 .line {
     stroke: rgba(128, 179, 236, 1);
     stroke-width: 1px;

--- a/site/src/examples/low-barrel/index.js
+++ b/site/src/examples/low-barrel/index.js
@@ -206,6 +206,22 @@
                     ]);
                 }
                 return data;
+            })
+            .decorate(function(sel) {
+                var height = Math.abs(chart.yScale().range()[0] - chart.yScale().range()[1]);
+                sel.enter()
+                    .selectAll('.resize.e>rect, .resize.w>rect')
+                    .style('visibility', 'visible')
+                    .attr('y', height / 4)
+                    .attr('rx', 4)
+                    .attr('ry', 4);
+
+                // As a y scale is set on the brush (multi does this),
+                // the brush component resets the height of the rect on every redraw,
+                // as such it has to be overridden within the update selection,
+                // rather than the enter selection
+                sel.selectAll('.resize.e>rect, .resize.w>rect')
+                    .attr('height', height / 2);
             });
 
         chart.plotArea(multi);
@@ -223,8 +239,7 @@
         if (data.dateDomain == null) {
             var maxDate = fc.util.extent(container.datum(), 'date')[1];
             var dateScale = d3.time.scale()
-                .domain([maxDate - 50 * 24 * 60 * 60 * 1000, maxDate])
-                .nice();
+                .domain([maxDate - 50 * 24 * 60 * 60 * 1000, maxDate]);
             data.dateDomain = dateScale.domain();
         }
 


### PR DESCRIPTION
Resolves #341.

![resize-handles](https://cloud.githubusercontent.com/assets/2017615/9568654/9fa08706-4f47-11e5-8dcf-cacf923ee6b3.PNG)
