### PR TITLE
Updated to use the public API for css-layout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,25 +122,7 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd: 'visual-tests/src/site/assets/',
-                        src: ['**/*.css', '**/*.js'],
-                        dest: 'visual-tests/dist/assets/',
-                    },
-                    {
-                        expand: true,
-                        cwd: 'node_modules/d3/',
-                        src: ['d3.js'],
-                        dest: 'visual-tests/dist/assets/',
-                    },
-                    {
-                        expand: true,
-                        cwd: 'node_modules/css-layout/dist/',
-                        src: ['css-layout.js'],
-                        dest: 'visual-tests/dist/assets/',
-                    },
-                    {
-                        expand: true,
-                        cwd: 'dist',
-                        src: ['d3fc.js', 'd3fc.css'],
+                        src: ['**'],
                         dest: 'visual-tests/dist/assets/',
                     },
                     {
@@ -151,21 +133,21 @@ module.exports = function (grunt) {
                     },
                     {
                         expand: true,
-                        cwd: 'node_modules/jquery/dist/',
-                        src: ['jquery.min.*'],
-                        dest: 'visual-tests/dist/assets/',
-                    },
-                    {
-                        expand: true,
                         cwd: 'visual-tests/src/test-fixtures/',
                         src: ['**/*', '!**/*.hbs'],
                         dest: 'visual-tests/dist/',
                     },
                     {
-                        expand: true,
-                        cwd: 'node_modules/seedrandom/',
-                        src: ['seedrandom.min.js'],
+                        src: [
+                            'node_modules/css-layout/dist/css-layout.js',
+                            'dist/d3fc.js',
+                            'dist/d3fc.css',
+                            'node_modules/jquery/dist/jquery.js',
+                            'node_modules/d3/d3.js',
+                            'node_modules/seedrandom/seedrandom.min.js'],
                         dest: 'visual-tests/dist/assets/',
+                        flatten: true,
+                        expand: true
                     }
                 ]
             },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,7 @@ module.exports = function (grunt) {
             site: {
                 src: [
                         'node_modules/d3/d3.js',
-                        'node_modules/css-layout/src/Layout.js',
+                        'node_modules/css-layout/dist/css-layout.js',
                         'dist/d3fc.js',
                         'node_modules/jquery/dist/jquery.js',
                         'node_modules/bootstrap/js/collapse.js',
@@ -133,8 +133,8 @@ module.exports = function (grunt) {
                     },
                     {
                         expand: true,
-                        cwd: 'node_modules/css-layout/src/',
-                        src: ['Layout.js'],
+                        cwd: 'node_modules/css-layout/dist/',
+                        src: ['css-layout.js'],
                         dest: 'visual-tests/dist/assets/',
                     },
                     {
@@ -289,7 +289,7 @@ module.exports = function (grunt) {
                 specs: '<%= meta.testJsFiles %>',
                 vendor: [
                     'node_modules/d3/d3.js',
-                    'node_modules/css-layout/src/Layout.js'
+                    'node_modules/css-layout/dist/css-layout.js'
                 ],
                 helpers: 'tests/beforeEachSpec.js'
             },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of components that make it easy to build interactive charts with D3",
   "author": "Scott Logic",
   "dependencies": {
-    "css-layout": "^0.0.2",
+    "css-layout": "^0.0.6",
     "d3": "^3.5.4"
   },
   "repository": {

--- a/site/src/components/introduction/1-getting-started.md
+++ b/site/src/components/introduction/1-getting-started.md
@@ -30,7 +30,11 @@ example-code: |
 
 ## Grabbing the code
 
-d3fc and its dependencies (D3, [css-layout](https://github.com/facebook/css-layout)) are available via npm. Simply install as follows:
+d3fc and its dependencies (D3, [css-layout](https://github.com/facebook/css-layout)) are available via npm or cdnjs.
+
+### Installing with npm
+
+You can install d3fc and its dependencies via npm as follows:
 
 ```
 npm install d3fc
@@ -40,10 +44,22 @@ Once installed, you can reference the d3fc JavaScript, CSS and dependencies with
 
 ```html
 <script src="node_modules/d3fc/node_modules/d3/d3.js"></script>
-<script src="node_modules/d3fc/node_modules/css-layout/src/Layout.js"></script>
+<script src="node_modules/d3fc/node_modules/css-layout/dist/css-layout.js"></script>
 <script src="node_modules/d3fc/dist/d3fc.js"></script>
 
 <link href="node_modules/d3fc/dist/d3fc.css" rel="stylesheet"/>
+```
+
+### Using cdnjs
+
+Alternatively you can link to d3fc and its dependencies directly via cdnjs:
+
+```html
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3fc/0.5.7/d3fc.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/css-layout/0.0.6/css-layout.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.js"></script>
+
+<link href="https://cdnjs.cloudflare.com/ajax/libs/d3fc/0.5.7/d3fc.css" rel="stylesheet"/>
 ```
 
 ## A quick chart

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -1,5 +1,5 @@
 /* globals computeLayout */
-(function(d3, fc, cssLayout) {
+(function(d3, fc, computeLayout) {
     'use strict';
 
 
@@ -76,13 +76,7 @@
             return {
                 style: parseStyle(el.getAttribute('layout-css')),
                 children: getChildNodes(el),
-                element: el,
-                layout: {
-                    width: undefined,
-                    height: undefined,
-                    top: 0,
-                    left: 0
-                }
+                element: el
             };
         }
 
@@ -114,7 +108,7 @@
                 layoutNodes.style.height = height !== -1 ? height : dimensions.height;
 
                 // use the Facebook CSS goodness
-                cssLayout.computeLayout(layoutNodes);
+                computeLayout(layoutNodes);
 
                 // apply the resultant layout
                 applyLayout(layoutNodes);

--- a/visual-tests/src/site/templates/includes/footer.hbs
+++ b/visual-tests/src/site/templates/includes/footer.hbs
@@ -1,5 +1,5 @@
 <script src="{{ assets }}/d3.js"></script>
-<script src="{{ assets }}/Layout.js"></script>
+<script src="{{ assets }}/css-layout.js"></script>
 <script src="{{ assets }}/d3fc.js"></script>
 <script src="{{ assets }}/seedrandom.min.js"></script>
 <script src="{{ assets }}/js/seed.js"></script> 

--- a/visual-tests/src/site/templates/layouts/index.hbs
+++ b/visual-tests/src/site/templates/layouts/index.hbs
@@ -20,7 +20,7 @@
       </div>
     </div>
     <footer>
-      <script src="{{assets}}/jquery.min.js"></script>
+      <script src="{{assets}}/jquery.js"></script>
       <script src="{{assets}}/bootstrap/js/bootstrap.min.js"></script>
       {{> footer }}
       <script src="{{assets}}/js/sidebar-nav.js"></script>


### PR DESCRIPTION
The `css-layout` project now has a properly defined public API, so we don't need to reference `src\Layout.js` directly any more. See this PR:

https://github.com/facebook/css-layout/pull/108

The public API performs a 'fill nodes' step to add the required `layout` property with default values.