### PR TITLE
Ensures that the version numbers for cdnjs are the most recent

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,8 @@ module.exports = function (grunt) {
                     partials: 'site/src/_includes/*.hbs',
                     layoutdir: 'site/src/_layouts',
                     layout: 'default',
-                    layoutext: '.hbs'
+                    layoutext: '.hbs',
+                    helpers: ['handlebars-helpers']
                 },
                 files: '<%= meta.siteFiles %>'
             }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jscs": "^1.8.0",
     "grunt-version": "^1.0.0",
+    "handlebars-helpers": "git://github.com/ColinEberhardt/handlebars-helpers.git",
     "jquery": "^1.11.2",
     "l": "0.0.1",
     "matchdep": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jscs": "^1.8.0",
     "grunt-version": "^1.0.0",
-    "handlebars-helpers": "git://github.com/ColinEberhardt/handlebars-helpers.git",
+    "handlebars-helpers": "ColinEberhardt/handlebars-helpers",
     "jquery": "^1.11.2",
     "l": "0.0.1",
     "matchdep": "^0.3.0",

--- a/site/src/components/introduction/1-getting-started.md
+++ b/site/src/components/introduction/1-getting-started.md
@@ -55,11 +55,11 @@ Once installed, you can reference the d3fc JavaScript, CSS and dependencies with
 Alternatively you can link to d3fc and its dependencies directly via cdnjs:
 
 ```html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3fc/0.5.7/d3fc.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/css-layout/0.0.6/css-layout.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3fc/{{ package.version }}/d3fc.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/css-layout/{{ slice package.dependencies.css-layout 1 }}/css-layout.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/{{ slice package.dependencies.d3 1 }}/d3.js"></script>
 
-<link href="https://cdnjs.cloudflare.com/ajax/libs/d3fc/0.5.7/d3fc.css" rel="stylesheet"/>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/d3fc/{{ package.version }}/d3fc.css" rel="stylesheet"/>
 ```
 
 ## A quick chart


### PR DESCRIPTION
Assemble was missing the string manipulation functionality I required, so I added `slice` to handlebars helpers:

https://github.com/assemble/handlebars-helpers/pull/194

