### PR TITLE
Removed the `orient` property exclusion from the axis rebinding

### DIFF
--- a/src/chart/linearTimeSeries.js
+++ b/src/chart/linearTimeSeries.js
@@ -99,12 +99,10 @@
             yNice: 'nice'
         });
 
-        var axisExclusions = [
-            'scale', // the scale is set to this component's scale
-            'orient' // the component layout does not support changes of orientation
-        ];
-        fc.util.rebindAll(linearTimeSeries, xAxis, 'x', axisExclusions);
-        fc.util.rebindAll(linearTimeSeries, yAxis, 'y', axisExclusions);
+        // Exclude scale when rebinding the axis properties because this component
+        // is responsible for providing the required scale.
+        fc.util.rebindAll(linearTimeSeries, xAxis, 'x', 'scale');
+        fc.util.rebindAll(linearTimeSeries, yAxis, 'y', 'scale');
 
         linearTimeSeries.xScale = function() { return xScale; };
         linearTimeSeries.yScale = function() { return yScale; };


### PR DESCRIPTION
Fixes #547 

This bug was introduced here:

https://github.com/ScottLogic/d3fc/pull/518/files#diff-6f455d17dcde9ea880da5741db76089eL110

I hadn't spotted that linearTimeSeries was rebinding `orient`. It didn't really feel logic to be rebinding that property, but clearly I was wrong as I was using it myself ;-)