### PR TITLE
Cartesian chart transitions

### DIFF
--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -99,7 +99,7 @@ function _layout() {
     return layout;
 }
 
-d3.selection.prototype.layout = function(name, value) {
+function layoutAdapter(name, value) {
     var layout = _layout();
     var n = arguments.length;
     if (n === 2) {
@@ -109,7 +109,7 @@ d3.selection.prototype.layout = function(name, value) {
             this.call(layout);
         } else {
             // layout(name, value) - sets a layout- attribute
-            this.attr('layout-css', name + ':' + value);
+            this.node().setAttribute('layout-css', name + ':' + value);
         }
     } else if (n === 1) {
         if (typeof name !== 'string') {
@@ -120,16 +120,19 @@ d3.selection.prototype.layout = function(name, value) {
                     return property + ':' + styleObject[property];
                 })
                 .join(';');
-            this.attr('layout-css', layoutCss);
+            this.node().setAttribute('layout-css', layoutCss);
         } else {
             // layout(name) - returns the value of the layout-name attribute
-            return Number(this.attr('layout-' + name));
+            return Number(this.node().getAttribute('layout-' + name));
         }
     } else if (n === 0) {
         // layout() - executes layout
         this.call(layout);
     }
     return this;
-};
+}
+
+d3.selection.prototype.layout = layoutAdapter;
+d3.transition.prototype.layout = layoutAdapter;
 
 export default _layout;

--- a/src/series/axis.js
+++ b/src/series/axis.js
@@ -25,22 +25,26 @@ export default function() {
 
             var g = dataJoin(this, [data]);
 
+            var translation;
             switch (axisAdapter.orient()) {
                 case 'top':
                 case 'bottom':
-                    g.attr('transform', 'translate(0,' + yScale(baseline(data)) + ')');
+                    translation = 'translate(0,' + yScale(baseline(data)) + ')';
                     axis.scale(xScale);
                     break;
 
                 case 'left':
                 case 'right':
-                    g.attr('transform', 'translate(' + xScale(baseline(data)) + ',0)');
+                    translation = 'translate(' + xScale(baseline(data)) + ',0)';
                     axis.scale(yScale);
                     break;
 
                 default:
                     throw new Error('Invalid orientation');
             }
+
+            g.enter().attr('transform', translation);
+            g.attr('transform', translation);
 
             g.call(axis);
 

--- a/visual-tests/src/test-fixtures/series/bar-transitions.js
+++ b/visual-tests/src/test-fixtures/series/bar-transitions.js
@@ -1,8 +1,6 @@
 (function(d3, fc) {
     'use strict';
 
-    //var transitionDuration = 2500;
-
     var dataset = [
         {name: 'Fred', age: 24},
         {name: 'Bob', age: 22},


### PR DESCRIPTION
Fixes #563 

After a bit of digging I found the underlying problem, our `layout` component is exposed on selections but not transitions. This means that if you call a component that uses `layout` from a transition, it fails.

This change adds `layout` to transitions. Also, transitions do not provide a 'getter' for the `attr` method, which is why this `layout` now drops down to the underlying DOM API.

