### PR TITLE
Fix Windows build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -109,7 +109,7 @@
         "func-style": 0,
         "indent": 2,
         "key-spacing": 2,
-        "linebreak-style": 2,
+        "linebreak-style": 0,
         "new-cap": 2,
         "new-parens": 2,
         "newline-after-var": 0,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "jquery": "^1.11.2",
     "jsdom": "^6.3.0",
     "matchdep": "^0.3.0",
-    "rollup": "^0.15.0",
+    "rollup": "^0.18.0",
     "seedrandom": "^2.4.0",
     "time-grunt": "^1.2.1"
   },


### PR DESCRIPTION
Update rollup to get Luke's Windows fixes.
ESLint complains about CRLF, but we use .gitattributes.