### PR TITLE
Added better links to documentation examples from examples on the site.

### DIFF
--- a/site/src/_layouts/example.hbs
+++ b/site/src/_layouts/example.hbs
@@ -53,6 +53,11 @@ layout: default
                     </li>
                 {{/is}}
               {{/each}}
+                <li class="{{#if this.isCurrentPage}}active{{/if}}">
+                    <a href="../components/introduction/1-getting-started.html">
+                        ...more in the Documentation
+                    </a>
+                </li>
             </ul>
           </li>
         {{/each}}

--- a/site/src/examples/index.md
+++ b/site/src/examples/index.md
@@ -22,3 +22,6 @@ A collection of more advanced examples.
     </a>
   </div>
 </div>
+
+Examples for specific components can be found in the [Documentation](../components/introduction/1-getting-started.html) section
+of the website.


### PR DESCRIPTION
As this was reported as issue here: https://github.com/ScottLogic/d3fc/issues/539 I decided to try fixing it. This is how it looks if you accept pull request:

http://pasteboard.co/1oGhQWgY.png