### PR TITLE
Stack bar fix

### DIFF
--- a/src/indicator/indicator.css
+++ b/src/indicator/indicator.css
@@ -23,3 +23,7 @@
   fill: none;
   stroke: #06c;
 }
+
+.bollinger path.area {
+  fill-opacity: 0.5;
+}

--- a/src/indicator/renderer/bollingerBands.js
+++ b/src/indicator/renderer/bollingerBands.js
@@ -45,7 +45,7 @@ export default function() {
             .decorate(function(g, data, index) {
                 g.enter()
                     .attr('class', function(d, i) {
-                        return 'multi ' + ['area', 'upper', 'lower', 'average'][i];
+                        return 'multi bollinger ' + ['area', 'upper', 'lower', 'average'][i];
                     });
                 decorate(g, data, index);
             });

--- a/src/series/xyBase.js
+++ b/src/series/xyBase.js
@@ -24,8 +24,8 @@ export default function() {
         return yScale(yValue(d, i));
     };
     base.defined = function(d, i) {
-        return x0Value(d, i) !== undefined && y0Value(d, i) !== undefined &&
-            xValue(d, i) !== undefined && yValue(d, i) !== undefined;
+        return x0Value(d, i) != null && y0Value(d, i) != null &&
+            xValue(d, i) != null && yValue(d, i) != null;
     };
 
     base.xScale = function(x) {

--- a/src/series/xyBase.js
+++ b/src/series/xyBase.js
@@ -24,8 +24,8 @@ export default function() {
         return yScale(yValue(d, i));
     };
     base.defined = function(d, i) {
-        return !isNaN(x0Value(d, i)) && !isNaN(y0Value(d, i)) &&
-            !isNaN(xValue(d, i)) && !isNaN(yValue(d, i));
+        return x0Value(d, i) !== undefined && y0Value(d, i) !== undefined &&
+            xValue(d, i) !== undefined && yValue(d, i) !== undefined;
     };
 
     base.xScale = function(x) {


### PR DESCRIPTION
Fixes #623 

The issue was with `xyBase` which changed the 'defined' rules to be strictly numeric.

I've also re-instated 0.5 opacity for bollinger fill, however rather than making all area series 0.5 opacity, this is now just applied to bollinger.