### PR TITLE
Don't add layout-width/height attributes to root node

### DIFF
--- a/site/src/examples/yahoo-finance-chart/index.js
+++ b/site/src/examples/yahoo-finance-chart/index.js
@@ -121,7 +121,6 @@ function renderChart(data) {
           left: 0
       });
 
-  var layout = fc.layout();
   container.layout();
 
   var volumeScale = d3.scale.linear()

--- a/src/fc.js
+++ b/src/fc.js
@@ -3,7 +3,6 @@ import chart from './chart/chart';
 import data from './data/data';
 import indicator from './indicator/indicator';
 import './layout/layout'; // import side-effects
-import layout from './layout/layout';
 import scale from './scale/scale';
 import series from './series/series';
 import svg from './svg/svg';
@@ -18,7 +17,6 @@ export default {
     chart: chart,
     data: data,
     indicator: indicator,
-    layout: layout,
     scale: scale,
     series: series,
     svg: svg,

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -9,102 +9,96 @@ function ownerSVGElement(node) {
     return node;
 }
 
-// the layout component performs flex-box layout on single DOM elements
-function layoutComponent() {
-
-    // parses the style attribute, converting it into a JavaScript object
-    function parseStyle(style) {
-        if (!style) {
-            return {};
-        }
-        var properties = style.split(';');
-        var json = {};
-        properties.forEach(function(property) {
-            var components = property.split(':');
-            if (components.length === 2) {
-                var name = components[0].trim();
-                var value = components[1].trim();
-                json[name] = isNaN(value) ? value : Number(value);
-            }
-        });
-        return json;
+// parses the style attribute, converting it into a JavaScript object
+function parseStyle(style) {
+    if (!style) {
+        return {};
     }
+    var properties = style.split(';');
+    var json = {};
+    properties.forEach(function(property) {
+        var components = property.split(':');
+        if (components.length === 2) {
+            var name = components[0].trim();
+            var value = components[1].trim();
+            json[name] = isNaN(value) ? value : Number(value);
+        }
+    });
+    return json;
+}
 
-    // creates the structure required by the layout engine
-    function createNodes(el) {
-        function getChildNodes() {
-            var children = [];
-            for (var i = 0; i < el.childNodes.length; i++) {
-                var child = el.childNodes[i];
-                if (child.nodeType === 1) {
-                    if (child.getAttribute('layout-style')) {
-                        children.push(createNodes(child));
-                    }
+// creates the structure required by the layout engine
+function createNodes(el) {
+    function getChildNodes() {
+        var children = [];
+        for (var i = 0; i < el.childNodes.length; i++) {
+            var child = el.childNodes[i];
+            if (child.nodeType === 1) {
+                if (child.getAttribute('layout-style')) {
+                    children.push(createNodes(child));
                 }
             }
-            return children;
         }
-        return {
-            style: parseStyle(el.getAttribute('layout-style')),
-            children: getChildNodes(el),
-            element: el
-        };
+        return children;
     }
-
-    // takes the result of layout and applied it to the SVG elements
-    function applyLayout(node, subtree) {
-        // don't set layout-width/height on layout root node
-        if (subtree) {
-            node.element.setAttribute('layout-width', node.layout.width);
-            node.element.setAttribute('layout-height', node.layout.height);
-        }
-        if (node.element.nodeName.match(/(?:svg|rect)/i)) {
-            node.element.setAttribute('width', node.layout.width);
-            node.element.setAttribute('height', node.layout.height);
-            node.element.setAttribute('x', node.layout.left);
-            node.element.setAttribute('y', node.layout.top);
-        } else {
-            node.element.setAttribute('transform',
-                'translate(' + node.layout.left + ', ' + node.layout.top + ')');
-        }
-        node.children.forEach(function(node) {
-            applyLayout(node, true);
-        });
-    }
-
-    function computeDimensions(node) {
-        if (node.hasAttribute('layout-width') && node.hasAttribute('layout-height')) {
-            return {
-                width: Number(node.getAttribute('layout-width')),
-                height: Number(node.getAttribute('layout-height'))
-            };
-        } else {
-            return innerDimensions(node);
-        }
-    }
-
-    var layout = function(node) {
-        if (ownerSVGElement(node).__layout__ === 'suspended') {
-            return;
-        }
-
-        var dimensions = computeDimensions(node);
-
-        // create the layout nodes
-        var layoutNodes = createNodes(node);
-
-        // set the width / height of the root
-        layoutNodes.style.width = dimensions.width;
-        layoutNodes.style.height = dimensions.height;
-
-        // use the Facebook CSS goodness
-        computeLayout(layoutNodes);
-
-        // apply the resultant layout
-        applyLayout(layoutNodes);
+    return {
+        style: parseStyle(el.getAttribute('layout-style')),
+        children: getChildNodes(el),
+        element: el
     };
+}
 
-    return layout;
+// takes the result of layout and applied it to the SVG elements
+function applyLayout(node, subtree) {
+    // don't set layout-width/height on layout root node
+    if (subtree) {
+        node.element.setAttribute('layout-width', node.layout.width);
+        node.element.setAttribute('layout-height', node.layout.height);
+    }
+    if (node.element.nodeName.match(/(?:svg|rect)/i)) {
+        node.element.setAttribute('width', node.layout.width);
+        node.element.setAttribute('height', node.layout.height);
+        node.element.setAttribute('x', node.layout.left);
+        node.element.setAttribute('y', node.layout.top);
+    } else {
+        node.element.setAttribute('transform',
+            'translate(' + node.layout.left + ', ' + node.layout.top + ')');
+    }
+    node.children.forEach(function(node) {
+        applyLayout(node, true);
+    });
+}
+
+function computeDimensions(node) {
+    if (node.hasAttribute('layout-width') && node.hasAttribute('layout-height')) {
+        return {
+            width: Number(node.getAttribute('layout-width')),
+            height: Number(node.getAttribute('layout-height'))
+        };
+    } else {
+        return innerDimensions(node);
+    }
+}
+
+function layout(node) {
+    if (ownerSVGElement(node).__layout__ === 'suspended') {
+        return;
+    }
+
+    var dimensions = computeDimensions(node);
+
+    // create the layout nodes
+    var layoutNodes = createNodes(node);
+
+    // set the width / height of the root
+    layoutNodes.style.width = dimensions.width;
+    layoutNodes.style.height = dimensions.height;
+
+    // use the Facebook CSS goodness
+    computeLayout(layoutNodes);
+
+    // apply the resultant layout
+    applyLayout(layoutNodes);
 }
 
 function layoutSuspended(x) {
@@ -130,8 +124,6 @@ function layoutSelection(name, value) {
 
     // for all other invocations, iterate over each item in the selection
     return this.each(function() {
-
-        var layout = layoutComponent();
         if (argsLength === 2) {
             if (typeof name !== 'string') {
                 // layout(number, number) - sets the width and height and performs layout
@@ -162,5 +154,3 @@ function layoutSelection(name, value) {
 
 d3.selection.prototype.layout = layoutSelection;
 d3.transition.prototype.layout = layoutSelection;
-
-export default layoutComponent;

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -122,7 +122,7 @@ function layoutComponent() {
 
 function layoutSuspended(x) {
     if (!arguments.length) {
-        return ownerSVGElement(this.node()).__layout__;
+        return Boolean(ownerSVGElement(this.node()).__layout__);
     }
     return this.each(function() {
         ownerSVGElement(this).__layout__ = x ? 'suspended' : '';

--- a/tests/layout/layoutSpec.js
+++ b/tests/layout/layoutSpec.js
@@ -130,4 +130,12 @@ describe('layout', function() {
         svgs.enter().append('g').layout('width');
     });
 
+    it('should not set layout-width/height attributes on root node', function() {
+        var svg = document.createElement('svg');
+        d3.select(svg)
+            .layout();
+        expect(svg.hasAttribute('layout-width')).toBe(false);
+        expect(svg.hasAttribute('layout-height')).toBe(false);
+    });
+
 });


### PR DESCRIPTION
See #643 for description of the bug. Also changes a couple of other things -

* Remove `fc.layout` component, I don't think it really needs to be exposed anymore.
* Force the return value of `.layoutSuspended()` to Boolean