### PR TITLE
[WIP] Adjusting indicators and multi to remove colour controls from indicators

### DIFF
--- a/src/fc.css
+++ b/src/fc.css
@@ -171,35 +171,20 @@ text {
 }
 
 /* Indicators */
-.macd-divergence .bar {
-  stroke: grey;
+.indicator .bar {
   fill: grey;
-  fill-opacity: 1.0;
 }
 
-.macd-signal .line {
-  stroke: red;
+.signal .line {
+  stroke-width: 2px;
 }
 
-.macd .line {
-  stroke: #06c;
+.indicator .line {
+  stroke-dasharray: 2, 2;
 }
 
-.stochastic-d .line {
-  stroke: red;
-}
-
-.stochastic-k .line {
-  stroke: #06c;
-}
-
-.bollinger .area {
-  fill: #9cf;
+.indicator .area {
   fill-opacity: 0.5;
-}
-
-.bollinger .line {
-  stroke: #06c;
 }
 
 /* Annotations */

--- a/src/indicator/renderer/bollingerBands.js
+++ b/src/indicator/renderer/bollingerBands.js
@@ -38,14 +38,14 @@ export default function() {
 
     var bollingerBands = function(selection) {
 
-        var multi = _multi()
+        var multi = _multi('bollinger')
             .xScale(xScale)
             .yScale(yScale)
             .series([area, upperLine, lowerLine, averageLine])
             .decorate(function(g, data, index) {
                 g.enter()
                     .attr('class', function(d, i) {
-                        return 'multi bollinger ' + ['area', 'upper', 'lower', 'average'][i];
+                        return 'bollinger ' + ['indicator', 'upper', 'lower', 'average'][i];
                     });
                 decorate(g, data, index);
             });

--- a/src/indicator/renderer/macd.js
+++ b/src/indicator/renderer/macd.js
@@ -13,7 +13,7 @@ export default function() {
         macdLine = _line(),
         signalLine = _line(),
         divergenceBar = _bar(),
-        multiSeries = _multi(),
+        multiSeries = _multi('macd'),
         decorate = noop;
 
     var macd = function(selection) {
@@ -33,7 +33,7 @@ export default function() {
             .decorate(function(g, data, index) {
                 g.enter()
                     .attr('class', function(d, i) {
-                        return 'multi ' + ['macd-divergence', 'macd', 'macd-signal'][i];
+                        return 'macd ' + ['indicator', 'indicator', 'signal'][i];
                     });
                 decorate(g, data, index);
             });

--- a/src/indicator/renderer/relativeStrengthIndex.js
+++ b/src/indicator/renderer/relativeStrengthIndex.js
@@ -1,6 +1,6 @@
 import d3 from 'd3';
 import annotationLine from '../../annotation/line';
-import _multi from '../../series/multi';
+import multiSeries from '../../series/multi';
 import {noop} from '../../util/fn';
 import seriesLine from '../../series/line';
 
@@ -10,7 +10,7 @@ export default function() {
         yScale = d3.scale.linear(),
         upperValue = 70,
         lowerValue = 30,
-        multiSeries = _multi(),
+        multi = multiSeries('rsi'),
         decorate = noop;
 
     var annotations = annotationLine();
@@ -19,9 +19,17 @@ export default function() {
 
     var rsi = function(selection) {
 
-        multiSeries.xScale(xScale)
+        multi
+            .xScale(xScale)
             .yScale(yScale)
-            .series([rsiLine, annotations])
+            .series([annotations, rsiLine])
+            .decorate(function(g, data, index) {
+                g.enter()
+                    .attr('class', function(d, i) {
+                        return 'rsi ' + ['', 'signal'][i];
+                    });
+                decorate(g, data, index);
+            })
             .mapping(function(series) {
                 if (series === annotations) {
                     return [
@@ -31,16 +39,9 @@ export default function() {
                     ];
                 }
                 return this;
-            })
-            .decorate(function(g, data, index) {
-                g.enter()
-                    .attr('class', function(d, i) {
-                        return 'multi rsi ' + ['indicator', 'annotations'][i];
-                    });
-                decorate(g, data, index);
             });
 
-        selection.call(multiSeries);
+        selection.call(multi);
     };
 
     rsi.xScale = function(x) {

--- a/src/indicator/renderer/stochasticOscillator.js
+++ b/src/indicator/renderer/stochasticOscillator.js
@@ -10,7 +10,7 @@ export default function() {
         yScale = d3.scale.linear(),
         upperValue = 80,
         lowerValue = 20,
-        multi = multiSeries(),
+        multi = multiSeries('stochastic'),
         decorate = noop;
 
     var annotations = lineAnnotation();
@@ -26,9 +26,17 @@ export default function() {
 
     var stochastic = function(selection) {
 
-        multi.xScale(xScale)
+        multi
+            .xScale(xScale)
             .yScale(yScale)
             .series([annotations, dLine, kLine])
+            .decorate(function(g, data, index) {
+                g.enter()
+                    .attr('class', function(d, i) {
+                        return 'stochastic ' + ['', 'signal', 'indicator'][i];
+                    });
+                decorate(g, data, index);
+            })
             .mapping(function(series) {
                 if (series === annotations) {
                     return [
@@ -37,13 +45,6 @@ export default function() {
                     ];
                 }
                 return this;
-            })
-            .decorate(function(g, data, index) {
-                g.enter()
-                    .attr('class', function(d, i) {
-                        return 'multi stochastic ' + ['annotations', 'stochastic-d', 'stochastic-k'][i];
-                    });
-                decorate(g, data, index);
             });
 
         selection.call(multi);

--- a/src/series/multi.js
+++ b/src/series/multi.js
@@ -9,7 +9,7 @@ import dataJoinUtil from '../util/dataJoin';
 // overriding where the series value is stored on the node (__series__) and
 // forcing the node datum (__data__) to be the user supplied data (via mapping).
 
-export default function() {
+export default function(className) {
 
     var xScale = d3.time.scale(),
         yScale = d3.scale.linear(),
@@ -18,10 +18,12 @@ export default function() {
         key = index,
         decorate = noop;
 
+    className = className || 'multi';
+
     var dataJoin = dataJoinUtil()
-        .selector('g.multi')
+        .selector('g.' + className)
         .children(true)
-        .attr('class', 'multi')
+        .attr('class', className)
         .element('g')
         .key(function(d, i) {
             // This function is invoked twice, the first pass is to pull the key


### PR DESCRIPTION
An idea from the work on the multi class allowing indicators (or anything else) to exclude themselves from the multi colours by setting the class name used by the multi series.

Normalised and unified all the indicator styles so common across the current set of indicators.

Goal was to make it so if we had two Bollinger bands then they would colour sequence. Also means don't need to fix their colour within the CSS file.