### PR TITLE
Axes come after data series in the DOM for cartesianChart

### DIFF
--- a/src/chart/cartesian.js
+++ b/src/chart/cartesian.js
@@ -93,13 +93,13 @@ export default function(xScale, yScale) {
                 <g class="plot-area-container"> \
                     <rect class="background" \
                         layout-style="position: absolute; top: 0; bottom: 0; left: 0; right: 0"/> \
+                    <svg class="plot-area" \
+                        layout-style="position: absolute; top: 0; bottom: 0; left: 0; right: 0"/> \
                     <svg class="axes-container" \
                         layout-style="position: absolute; top: 0; bottom: 0; left: 0; right: 0"> \
                         <g class="x-axis" layout-style="height: 0; width: 0"/> \
                         <g class="y-axis" layout-style="height: 0; width: 0"/> \
                     </svg> \
-                    <svg class="plot-area" \
-                        layout-style="position: absolute; top: 0; bottom: 0; left: 0; right: 0"/> \
                 </g>');
 
             var expandedMargin = expandMargin(margin);


### PR DESCRIPTION
The 'axes-container' SVG element is moved to come after 'plot-area', ensuring axes and their labels appear on top of the chart.

Without this the axes labels are easily obscured by area series.

I can't think of any cases where axes below plot data would be desirable, but please feel free to prove me wrong.
