### PR TITLE
Adjusted fc.util.extent to be component #646

### DIFF
--- a/site/src/components/chart/cartesian.md
+++ b/site/src/components/chart/cartesian.md
@@ -18,8 +18,8 @@ example-code: |
   var chart = fc.chart.cartesian(
                 d3.scale.linear(),
                 d3.scale.linear())
-            .xDomain(fc.util.extent(data, 'x'))
-            .yDomain(fc.util.extent(data, 'y'));
+            .xDomain(fc.util.extent()(data, 'x'))
+            .yDomain(fc.util.extent()(data, 'y'));
 
   // create a series and associate it with the plot area
   var line = fc.series.line()
@@ -49,10 +49,10 @@ example-code-2: |
                 d3.scale.linear(),
                 d3.scale.linear())
             .margin({left: 50, bottom: 20})
-            .xDomain(fc.util.extent(data, 'x'))
+            .xDomain(fc.util.extent()(data, 'x'))
             .xLabel('value')
             .xBaseline(0)
-            .yDomain(fc.util.extent(data, ['y', 'z']))
+            .yDomain(fc.util.extent()(data, ['y', 'z']))
             .yNice()
             .yOrient('left')
             .yLabel('Sine / Cosine');

--- a/site/src/components/chart/linearTimeSeries.md
+++ b/site/src/components/chart/linearTimeSeries.md
@@ -11,9 +11,9 @@ example-code: |
 
   // create a chart
   var chart = fc.chart.linearTimeSeries()
-      .xDomain(fc.util.extent(data, 'date'))
+      .xDomain(fc.util.extent()(data, 'date'))
       .xTicks(5)
-      .yDomain(fc.util.extent(data, ['high', 'low']))
+      .yDomain(fc.util.extent()(data, ['high', 'low']))
       .yNice()
       .yTicks(5);
 

--- a/site/src/components/chart/sparkline.md
+++ b/site/src/components/chart/sparkline.md
@@ -23,8 +23,8 @@ example-code: |
           var data = fc.data.random.financial()(50);
 
           var chart = fc.chart.sparkline()
-              .xDomain(fc.util.extent(data, 'date'))
-              .yDomain(fc.util.extent(data, 'low'))
+              .xDomain(fc.util.extent()(data, 'date'))
+              .yDomain(fc.util.extent()(data, 'low'))
               .radius(2)
               .yValue(function(d) { return d.low; });
 

--- a/site/src/components/introduction/1-getting-started.md
+++ b/site/src/components/introduction/1-getting-started.md
@@ -7,8 +7,8 @@ example-code: |
     var data = fc.data.random.financial()(50);
 
     var chart = fc.chart.linearTimeSeries()
-        .xDomain(fc.util.extent(data, 'date'))
-        .yDomain(fc.util.extent(data, ['high', 'low']));
+        .xDomain(fc.util.extent()(data, 'date'))
+        .yDomain(fc.util.extent()(data, ['high', 'low']));
 
     var gridlines = fc.annotation.gridline();
     var candlestick = fc.series.candlestick();

--- a/site/src/components/scale/dateTime.md
+++ b/site/src/components/scale/dateTime.md
@@ -7,13 +7,13 @@ namespace: scale
 example-code: |
   // create the d3fc scale
   var dateScale = fc.scale.dateTime()
-      .domain(fc.util.extent(data, 'date'))
+      .domain(fc.util.extent()(data, 'date'))
       .range([0, width]);
 
 example2-code: |
   // create the d3fc scale
   var dateScale = fc.scale.dateTime()
-      .domain(fc.util.extent(data, 'date'))
+      .domain(fc.util.extent()(data, 'date'))
       .discontinuityProvider(fc.scale.discontinuity.skipWeekends())
       .range([0, width]);
 

--- a/site/src/components/series/cycle.md
+++ b/site/src/components/series/cycle.md
@@ -19,12 +19,12 @@ example-code: |
       .rangePoints([0, width], 1.0);
 
   var salesScale = d3.scale.linear()
-      .domain(fc.util.extent(data, 'sales'))
+      .domain(fc.util.extent()(data, 'sales'))
       .range([height, 0])
       .nice();
 
   var subScale = d3.scale.linear()
-      .domain(fc.util.extent(data, 'date'));
+      .domain(fc.util.extent()(data, 'date'));
 
   var subAxis = fc.series.axis()
       .tickSize(0)

--- a/site/src/components/series/grouped-bar.md
+++ b/site/src/components/series/grouped-bar.md
@@ -26,7 +26,7 @@ example-code: |
       .rangePoints([0, width], 1);
 
   var y = d3.scale.linear()
-    .domain(fc.util.extent(series, function(d) { return 0; }, 'y'))
+    .domain(fc.util.extent()(series, function(d) { return 0; }, 'y'))
     .range([height, 0]);
 
   // create the grouped bar series

--- a/site/src/components/series/grouped-bar.md
+++ b/site/src/components/series/grouped-bar.md
@@ -26,7 +26,7 @@ example-code: |
       .rangePoints([0, width], 1);
 
   var y = d3.scale.linear()
-    .domain(fc.util.extent()(series, function(d) { return 0; }, 'y'))
+    .domain(fc.util.extent().include(0)(series, 'y'))
     .range([height, 0]);
 
   // create the grouped bar series

--- a/site/src/components/series/multi.md
+++ b/site/src/components/series/multi.md
@@ -30,8 +30,8 @@ example-mapping: |
     bar: fc.data.random.financial()(25)
   };
 
-  xScale.domain(fc.util.extent([data.foo, data.bar], ['date']))
-  yScale.domain(fc.util.extent([data.foo, data.bar], ['high', 'low']));
+  xScale.domain(fc.util.extent()([data.foo, data.bar], ['date']))
+  yScale.domain(fc.util.extent()([data.foo, data.bar], ['high', 'low']));
 
   var line = fc.series.line();
   var area = fc.series.area();

--- a/site/src/components/series/stacked.md
+++ b/site/src/components/series/stacked.md
@@ -30,7 +30,7 @@ example-code: |
       .rangePoints([0, width], 1);
 
   var y = d3.scale.linear()
-    .domain(fc.util.extent(series, function(d) { return 0; },
+    .domain(fc.util.extent()(series, function(d) { return 0; },
                             function(d) { return d.y + d.y0; }))
     .range([height, 0]);
 

--- a/site/src/components/series/stacked.md
+++ b/site/src/components/series/stacked.md
@@ -30,8 +30,7 @@ example-code: |
       .rangePoints([0, width], 1);
 
   var y = d3.scale.linear()
-    .domain(fc.util.extent()(series, function(d) { return 0; },
-                            function(d) { return d.y + d.y0; }))
+    .domain(fc.util.extent().include(0)(series, function(d) { return d.y + d.y0; }))
     .range([height, 0]);
 
   // create the stacked bar series (this could also be line or area)

--- a/site/src/examples/basecoin/index.js
+++ b/site/src/examples/basecoin/index.js
@@ -136,7 +136,7 @@
                     .range([0, WIDTH * 0.5]);
 
                 var yScale = d3.scale.linear()
-                    .domain(fc.util.extent(data, ['low', 'high']))
+                    .domain(fc.util.extent()(data, ['low', 'high']))
                     // Modify the range so that the series only takes up middle third of the the width
                     .range([HEIGHT * 0.66, HEIGHT * 0.33]);
 

--- a/site/src/examples/low-barrel/index.js
+++ b/site/src/examples/low-barrel/index.js
@@ -150,7 +150,7 @@
                 crosshairs.snap(fc.util.seriesPointSnapXOnly(candlestick, data));
 
                 chart.xDomain(data.dateDomain)
-                    .yDomain(fc.util.extent(data, ['high', 'low']))
+                    .yDomain(fc.util.extent()(data, ['high', 'low']))
                     .yNice();
 
                 var container = d3.select(this)
@@ -250,7 +250,7 @@
             selection.each(function(data) {
 
                 chart.xDomain(data.dateDomain)
-                    .yDomain(fc.util.extent(data, 'volume'))
+                    .yDomain(fc.util.extent()(data, 'volume'))
                     .yNice();
 
                 bar.y0Value(chart.yDomain()[0]);
@@ -409,11 +409,11 @@
 
         // Enhance data with interactive state
         data.crosshairs = [];
-        var maxDate = fc.util.extent(data, 'date')[1];
+        var maxDate = fc.util.extent()(data, 'date')[1];
         var minDate = new Date(maxDate - 50 * 24 * 60 * 60 * 1000);
         data.dateDomain = [minDate, maxDate];
-        data.navigatorDateDomain = fc.util.extent(data, 'date');
-        data.navigatorYDomain = fc.util.extent(data, 'close');
+        data.navigatorDateDomain = fc.util.extent()(data, 'date');
+        data.navigatorYDomain = fc.util.extent()(data, 'close');
 
         var container = d3.select('#low-barrel')
             .layout();

--- a/site/src/examples/yahoo-finance-chart/index.js
+++ b/site/src/examples/yahoo-finance-chart/index.js
@@ -132,9 +132,9 @@ function renderChart(data) {
 
   // add a time series components
   var chart = fc.chart.linearTimeSeries()
-        .xDomain(fc.util.extent(data, 'date'))
+        .xDomain(fc.util.extent()(data, 'date'))
         .xDiscontinuityProvider(discontinuity)
-        .yDomain(fc.util.extent(data, ['open', 'close']))
+        .yDomain(fc.util.extent()(data, ['open', 'close']))
         .xTickFormat(dateFormat)
         .yTickFormat(priceFormat)
         .yTicks(5)

--- a/site/src/index.hbs
+++ b/site/src/index.hbs
@@ -12,7 +12,7 @@ example-code: |
    data.shift();
 
    // Offset the range to include the full bar for the latest value
-   var dateRange = fc.util.extent(data, 'date');
+   var dateRange = fc.util.extent()(data, 'date');
    dateRange[1] = d3.time.day.offset(dateRange[1], 1);
 
    // create a chart
@@ -26,7 +26,7 @@ example-code: |
    var bollingerAlgorithm = fc.indicator.algorithm.bollingerBands();
    bollingerAlgorithm(data);
 
-   chart.yDomain(fc.util.extent(data, [
+   chart.yDomain(fc.util.extent()(data, [
       function(d) { return d.bollingerBands.upper; },
       function(d) { return d.bollingerBands.lower; }
    ]));

--- a/site/src/lib/init.js
+++ b/site/src/lib/init.js
@@ -19,12 +19,12 @@ function createFixture(elementId, desiredWidth, desiredHeight, numPoints, filter
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width]);
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/src/util/extent.js
+++ b/src/util/extent.js
@@ -4,54 +4,62 @@ import d3 from 'd3';
  * The extent function enhances the functionality of the equivalent D3 extent function, allowing
  * you to pass an array of fields, or accessors, which will be used to derive the extent of the supplied array. For
  * example, if you have an array of items with properties of 'high' and 'low', you
- * can use <code>fc.util.extent(data, ['high', 'low'])</code> to compute the extent of your data.
+ * can use <code>fc.util.extent()(data, ['high', 'low'])</code> to compute the extent of your data.
  *
  * @memberof fc.util
- * @param {array} data an array of data points, or an array of arrays of data points
- * @param {array} fields the names of object properties that represent field values, or accessor functions.
  */
-export default function(data, fields) {
+export default function() {
 
-    // we need an array of arrays if we don't have one already
-    if (!Array.isArray(data[0])) {
-        data = [data];
-    }
-    if (arguments.length === 2) {
-        // the fields parameter must be an array of field names, but we can pass non-array types in
-        if (!Array.isArray(fields)) {
-            fields = [fields];
+    /**
+    * @param {array} data an array of data points, or an array of arrays of data points
+    * @param {array} fields the names of object properties that represent field values, or accessor functions.
+    */
+    var extents = function(data, fields) {
+
+        // we need an array of arrays if we don't have one already
+        if (!Array.isArray(data[0])) {
+            data = [data];
         }
-    } else {
-        // for > 2 args, construct the fields
-        var args = Array.prototype.slice.call(arguments);
-        fields = args.slice(1);
-    }
-
-    // the fields can be a mixed array of property names or accessor functions
-    fields = fields.map(function(field) {
-        if (typeof field !== 'string') {
-            return field;
+        if (arguments.length === 2) {
+            // the fields parameter must be an array of field names,
+            // but we can pass non-array types in
+            if (!Array.isArray(fields)) {
+                fields = [fields];
+            }
+        } else {
+            // for > 2 args, construct the fields
+            var args = Array.prototype.slice.call(arguments);
+            fields = args.slice(1);
         }
-        return function(d) {
-            return d[field];
-        };
-    });
 
-    // Return the smallest and largest
-    return [
-        d3.min(data, function(d0) {
-            return d3.min(d0, function(d1) {
-                return d3.min(fields.map(function(f) {
-                    return f(d1);
-                }));
-            });
-        }),
-        d3.max(data, function(d0) {
-            return d3.max(d0, function(d1) {
-                return d3.max(fields.map(function(f) {
-                    return f(d1);
-                }));
-            });
-        })
-    ];
+        // the fields can be a mixed array of property names or accessor functions
+        fields = fields.map(function(field) {
+            if (typeof field !== 'string') {
+                return field;
+            }
+            return function(d) {
+                return d[field];
+            };
+        });
+
+        // Return the smallest and largest
+        return [
+            d3.min(data, function(d0) {
+                return d3.min(d0, function(d1) {
+                    return d3.min(fields.map(function(f) {
+                        return f(d1);
+                    }));
+                });
+            }),
+            d3.max(data, function(d0) {
+                return d3.max(d0, function(d1) {
+                    return d3.max(fields.map(function(f) {
+                        return f(d1);
+                    }));
+                });
+            })
+        ];
+    };
+
+    return extents;
 }

--- a/tests/util/extentsSpec.js
+++ b/tests/util/extentsSpec.js
@@ -116,14 +116,14 @@ describe('fc.util.extent', function() {
         expect(extents).toEqual([5, 30]);
     });
 
-    it('should only pad numbers', function() {
-        var date1 = new Date(2014, 0);
-        var date2 = new Date(2015, 0);
+    it('should pad dates', function() {
+        var date1 = new Date(2014, 0, 10);
+        var date2 = new Date(2014, 0, 20);
         var data = [{date: date1}, {date: date2}];
 
         var extents = fc.util.extent()
             .pad(1)(data, 'date');
-        expect(extents).toEqual([date1, date2]);
+        expect(extents).toEqual([new Date(2014, 0, 5), new Date(2014, 0, 25)]);
     });
 
 });

--- a/tests/util/extentsSpec.js
+++ b/tests/util/extentsSpec.js
@@ -53,4 +53,77 @@ describe('fc.util.extent', function() {
         expect(extents).toEqual([6, 115]);
     });
 
+    it('should support including a max value in the range', function() {
+        var data = [obj(1), obj(2)];
+
+        var extents = fc.util.extent()
+            .include(10)(data, 'high');
+        expect(extents).toEqual([6, 10]);
+    });
+
+    it('should support including a min value in the range', function() {
+        var data = [obj(1), obj(2)];
+
+        var extents = fc.util.extent()
+            .include(0)(data, 'high');
+        expect(extents).toEqual([0, 7]);
+    });
+
+    it('should support including a value within the range', function() {
+        var data = [obj(1), obj(3)];
+
+        var extents = fc.util.extent()
+            .include(7)(data, 'high');
+        expect(extents).toEqual([6, 8]);
+    });
+
+    it('should support increasing the range', function() {
+        var data = [obj(5), obj(15)];
+
+        var extents = fc.util.extent()
+            .pad(1)(data, 'high');
+        expect(extents).toEqual([5, 25]);
+    });
+
+    it('should support padding an empty dataset', function() {
+        var data = [];
+
+        var extents = fc.util.extent()
+            .pad(2)(data, 'high');
+        expect(isNaN(extents[0])).toBe(true);
+        expect(isNaN(extents[1])).toBe(true);
+    });
+
+    it('should support padding zero as an identity', function() {
+        var data = [obj(1), obj(2)];
+
+        var extents = fc.util.extent()
+            .pad(0)(data, 'high');
+        expect(extents).toEqual([6, 7]);
+    });
+
+    it('should pad the range, then include the extra point', function() {
+        var data = [obj(5), obj(15)];
+
+        var extents = fc.util.extent()
+            .include(0)
+            .pad(1)(data, 'high');
+        expect(extents).toEqual([0, 25]);
+
+        extents = fc.util.extent()
+            .include(30)
+            .pad(1)(data, 'high');
+        expect(extents).toEqual([5, 30]);
+    });
+
+    it('should only pad numbers', function() {
+        var date1 = new Date(2014, 0);
+        var date2 = new Date(2015, 0);
+        var data = [{date: date1}, {date: date2}];
+
+        var extents = fc.util.extent()
+            .pad(1)(data, 'date');
+        expect(extents).toEqual([date1, date2]);
+    });
+
 });

--- a/tests/util/extentsSpec.js
+++ b/tests/util/extentsSpec.js
@@ -10,17 +10,17 @@ describe('fc.util.extent', function() {
     it('should compute extents based on the supplied fields', function() {
         var data = [obj(1), obj(2), obj(10)];
 
-        var extents = fc.util.extent(data, ['high']);
+        var extents = fc.util.extent()(data, ['high']);
         expect(extents).toEqual([6, 15]);
 
-        extents = fc.util.extent(data, ['high', 'low']);
+        extents = fc.util.extent()(data, ['high', 'low']);
         expect(extents).toEqual([-4, 15]);
     });
 
     it('should support a single field name', function() {
         var data = [obj(1), obj(2), obj(10)];
 
-        var extents = fc.util.extent(data, 'high');
+        var extents = fc.util.extent()(data, 'high');
         expect(extents).toEqual([6, 15]);
     });
 
@@ -28,28 +28,28 @@ describe('fc.util.extent', function() {
         var data = [obj(2), obj(1)];
         var data2 = [obj(4), obj(5)];
 
-        var extents = fc.util.extent([data, data2], 'high');
+        var extents = fc.util.extent()([data, data2], 'high');
         expect(extents).toEqual([6, 10]);
     });
 
     it('should support accessor functions', function() {
         var data = [obj(1), obj(2), obj(10)];
 
-        var extents = fc.util.extent(data, [function(d) { return d.high + 100; }]);
+        var extents = fc.util.extent()(data, [function(d) { return d.high + 100; }]);
         expect(extents).toEqual([106, 115]);
     });
 
     it('should support varargs field names', function() {
         var data = [obj(1), obj(2), obj(10)];
 
-        var extents = fc.util.extent(data, 'low', 'high');
+        var extents = fc.util.extent()(data, 'low', 'high');
         expect(extents).toEqual([-4, 15]);
     });
 
     it('should support mixed field names and accessor functions', function() {
         var data = [obj(1), obj(2), obj(10)];
 
-        var extents = fc.util.extent(data, 'high', function(d) { return d.high + 100; });
+        var extents = fc.util.extent()(data, 'high', function(d) { return d.high + 100; });
         expect(extents).toEqual([6, 115]);
     });
 

--- a/visual-tests/annotation/band.js
+++ b/visual-tests/annotation/band.js
@@ -12,13 +12,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([100, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/annotation/line.js
+++ b/visual-tests/annotation/line.js
@@ -12,13 +12,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([100, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/chart/cartesian.js
+++ b/visual-tests/chart/cartesian.js
@@ -72,8 +72,8 @@
         var chart = fc.chart.cartesian(
                 isOrdinal ? d3.scale.ordinal() : d3.scale.linear(),
                 d3.scale.linear())
-            .xDomain(isOrdinal ? data.map(function(d) { return d.name; }) : fc.util.extent(data, 'x'))
-            .yDomain(isOrdinal ? [0, 50] : fc.util.extent(data, 'y'))
+            .xDomain(isOrdinal ? data.map(function(d) { return d.name; }) : fc.util.extent()(data, 'x'))
+            .yDomain(isOrdinal ? [0, 50] : fc.util.extent()(data, 'y'))
             .yOrient(chartConfig[0].value)
             .xOrient(chartConfig[1].value)
             .yLabel(chartConfig[2].value)

--- a/visual-tests/chart/sparkline.js
+++ b/visual-tests/chart/sparkline.js
@@ -13,8 +13,8 @@
             var data = fc.data.random.financial()(50);
 
             var chart = fc.chart.sparkline()
-                .xDomain(fc.util.extent(data, 'date'))
-                .yDomain(fc.util.extent(data, 'low'))
+                .xDomain(fc.util.extent()(data, 'date'))
+                .yDomain(fc.util.extent()(data, 'low'))
                 .radius(2)
                 .yValue(function(d) { return d.low; });
 

--- a/visual-tests/functional/decorate.js
+++ b/visual-tests/functional/decorate.js
@@ -15,33 +15,33 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width]);
 
     var heightFraction = height / 4;
 
     // Create scale for y axis
     var candleScale = d3.scale.linear()
-        .domain(fc.util.extent(data3, ['high', 'low']))
+        .domain(fc.util.extent()(data3, ['high', 'low']))
         .range([heightFraction, 0]);
 
     var ohlcScale = d3.scale.linear()
-        .domain(fc.util.extent(data2, ['high', 'low']))
+        .domain(fc.util.extent()(data2, ['high', 'low']))
         .range([heightFraction * 2, heightFraction]);
 
     // offset the close price to give some negative values
-    var extent = fc.util.extent(data, ['close']);
+    var extent = fc.util.extent()(data, ['close']);
     var offset = extent[0] + (extent[1] - extent[0]) / 2;
     data.forEach(function(datum) {
         datum.close = datum.close - offset;
     });
 
     var barScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['close']))
+        .domain(fc.util.extent()(data, ['close']))
         .range([heightFraction * 3, heightFraction * 2]);
 
     var pointScale = d3.scale.linear()
-        .domain(fc.util.extent(data4, ['high', 'low']))
+        .domain(fc.util.extent()(data4, ['high', 'low']))
         .range([heightFraction * 4, heightFraction * 3]);
 
     var color = d3.scale.category10();

--- a/visual-tests/functional/update.js
+++ b/visual-tests/functional/update.js
@@ -14,13 +14,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 
@@ -75,8 +75,8 @@
         data.forEach(function(d) {
             d.low = d.low - 0.1;
         });
-        dateScale.domain(fc.util.extent(data, 'date'));
-        priceScale.domain(fc.util.extent(data, ['high', 'low']));
+        dateScale.domain(fc.util.extent()(data, 'date'));
+        priceScale.domain(fc.util.extent()(data, ['high', 'low']));
         render();
     }, 1000);
 })(d3, fc);

--- a/visual-tests/indicator/bollingerBands.js
+++ b/visual-tests/indicator/bollingerBands.js
@@ -12,7 +12,7 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .discontinuityProvider(fc.scale.discontinuity.skipWeekends())
         .range([0, width]);
 
@@ -35,7 +35,7 @@
         .merge(function(datum, boll) { datum.boll = boll; });
     bollingerComputer(data);
 
-    priceScale.domain(fc.util.extent(data, [
+    priceScale.domain(fc.util.extent()(data, [
         function(d) { return d.boll.upper; },
         function(d) { return d.boll.lower; }
     ]));

--- a/visual-tests/indicator/exponentialMovingAverage.js
+++ b/visual-tests/indicator/exponentialMovingAverage.js
@@ -12,13 +12,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/indicator/macd.js
+++ b/visual-tests/indicator/macd.js
@@ -15,7 +15,7 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 

--- a/visual-tests/indicator/movingAverage.js
+++ b/visual-tests/indicator/movingAverage.js
@@ -17,13 +17,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/indicator/relativeStrengthIndex.js
+++ b/visual-tests/indicator/relativeStrengthIndex.js
@@ -12,7 +12,7 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 

--- a/visual-tests/indicator/stochasticOscillator.js
+++ b/visual-tests/indicator/stochasticOscillator.js
@@ -12,7 +12,7 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 

--- a/visual-tests/series/area-line-interpolate.js
+++ b/visual-tests/series/area-line-interpolate.js
@@ -12,13 +12,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/series/area-line-point.js
+++ b/visual-tests/series/area-line-point.js
@@ -12,13 +12,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/series/axis.js
+++ b/visual-tests/series/axis.js
@@ -19,11 +19,11 @@
     }
 
     var xScale = d3.scale.linear()
-        .domain(fc.util.extent(data, 'theta'))
+        .domain(fc.util.extent()(data, 'theta'))
         .range([0, width]);
 
     var yScale = d3.scale.linear()
-        .domain(fc.util.extent(data, 'sin', 'cos'))
+        .domain(fc.util.extent()(data, 'sin', 'cos'))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/series/bar-transitions.js
+++ b/visual-tests/series/bar-transitions.js
@@ -33,7 +33,7 @@
                 d3.scale.ordinal(), d3.scale.linear())
             .xBaseline(0)
             .xDomain(data.map(function(d) { return d.name; }))
-            .yDomain(clampRange(fc.util.extent(data, 'age')));
+            .yDomain(clampRange(fc.util.extent()(data, 'age')));
 
         // Create the bar series
         var bar = fc.series.bar()

--- a/visual-tests/series/bar.js
+++ b/visual-tests/series/bar.js
@@ -15,11 +15,11 @@
 
         // Create scale for x axis
         var dateScale = fc.scale.dateTime()
-            .domain(fc.util.extent(data, 'date'))
+            .domain(fc.util.extent()(data, 'date'))
             .range([0, width]);
 
         // offset the close price to give some negative values
-        var extent = fc.util.extent(data, ['close']);
+        var extent = fc.util.extent()(data, ['close']);
         var offset = extent[0] + (extent[1] - extent[0]) / 2;
         data.forEach(function(datum) {
             datum.close = datum.close - offset;
@@ -27,7 +27,7 @@
 
         // Create scale for y axis
         var priceScale1 = d3.scale.linear()
-            .domain(fc.util.extent(data, ['close']))
+            .domain(fc.util.extent()(data, ['close']))
             .range([0, height / 2]);
 
         var bar1 = fc.series.bar()
@@ -42,7 +42,7 @@
 
         // Create scale for y axis
         var priceScale2 = d3.scale.linear()
-            .domain(fc.util.extent(data, ['close']))
+            .domain(fc.util.extent()(data, ['close']))
             .range([height / 2, height]);
 
         var bar2 = fc.series.bar()
@@ -61,7 +61,7 @@
             (15);
 
         // offset the low price to give some negative values
-        var extent = fc.util.extent(data, ['low']);
+        var extent = fc.util.extent()(data, ['low']);
         var offset = extent[0] + (extent[1] - extent[0]) / 2;
         data.forEach(function(datum) {
             datum.low = datum.low - offset;
@@ -76,12 +76,12 @@
 
         // Create scale for y axis
         var dateScale = fc.scale.dateTime()
-            .domain(fc.util.extent(data, 'date'))
+            .domain(fc.util.extent()(data, 'date'))
             .range([0, height]);
 
         // Create scale for x axis
         var priceScale = d3.scale.linear()
-            .domain(fc.util.extent(data, ['low']))
+            .domain(fc.util.extent()(data, ['low']))
             .range([0, width]);
 
         var bar = fc.series.bar()

--- a/visual-tests/series/candlestick.js
+++ b/visual-tests/series/candlestick.js
@@ -12,13 +12,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/series/comparison.js
+++ b/visual-tests/series/comparison.js
@@ -24,13 +24,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['percentageChange']))
+        .domain(fc.util.extent()(data, ['percentageChange']))
         .range([height, 0])
         .nice();
 
@@ -76,7 +76,7 @@
                         tuple[0].percentageChange = tuple[1];
                     });
             });
-            priceScale.domain(fc.util.extent(comparisonData, ['percentageChange']))
+            priceScale.domain(fc.util.extent()(comparisonData, ['percentageChange']))
                 .nice();
             render();
         })

--- a/visual-tests/series/cycle.js
+++ b/visual-tests/series/cycle.js
@@ -32,11 +32,11 @@
             .rangePoints([0, width], 1);
 
         var yearScale = d3.scale.linear()
-            .domain(fc.util.extent(data, 'Year'))
+            .domain(fc.util.extent()(data, 'Year'))
             .nice();
 
         var tempScale = d3.scale.linear()
-            .domain(fc.util.extent(data, ['Station']))
+            .domain(fc.util.extent()(data, ['Station']))
             .range([height, 0])
             .nice();
 

--- a/visual-tests/series/grouped-bar.js
+++ b/visual-tests/series/grouped-bar.js
@@ -21,7 +21,7 @@
                 d3.scale.ordinal(),
                 d3.scale.linear())
             .xDomain(data.map(function(d) { return d.State; }))
-            .yDomain(fc.util.extent(series, function(d) { return 0; }, 'y'))
+            .yDomain(fc.util.extent()(series, function(d) { return 0; }, 'y'))
             .margin({right: 50, bottom: 50});
 
         var groupedBar = fc.series.groupedBar()

--- a/visual-tests/series/grouped-bar.js
+++ b/visual-tests/series/grouped-bar.js
@@ -21,7 +21,7 @@
                 d3.scale.ordinal(),
                 d3.scale.linear())
             .xDomain(data.map(function(d) { return d.State; }))
-            .yDomain(fc.util.extent()(series, function(d) { return 0; }, 'y'))
+            .yDomain(fc.util.extent().include(0)(series, 'y'))
             .margin({right: 50, bottom: 50});
 
         var groupedBar = fc.series.groupedBar()

--- a/visual-tests/series/ohlc.js
+++ b/visual-tests/series/ohlc.js
@@ -12,13 +12,13 @@
 
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
-        .domain(fc.util.extent(data, 'date'))
+        .domain(fc.util.extent()(data, 'date'))
         .range([0, width])
         .nice();
 
     // Create scale for y axis
     var priceScale = d3.scale.linear()
-        .domain(fc.util.extent(data, ['high', 'low']))
+        .domain(fc.util.extent()(data, ['high', 'low']))
         .range([height, 0])
         .nice();
 

--- a/visual-tests/series/stacked-bar.js
+++ b/visual-tests/series/stacked-bar.js
@@ -39,7 +39,7 @@
                 d3.scale.ordinal(),
                 d3.scale.linear())
             .xDomain(data.map(function(d) { return d.State; }))
-            .yDomain(fc.util.extent()(series, function(d) { return 0; }, function(d) { return d.y + d.y0; }))
+            .yDomain(fc.util.extent().include(0)(series, function(d) { return d.y + d.y0; }))
             .margin({right: 50, bottom: 50});
 
         var stackedBar = fc.series.stacked[seriesType]()

--- a/visual-tests/series/stacked-bar.js
+++ b/visual-tests/series/stacked-bar.js
@@ -39,7 +39,7 @@
                 d3.scale.ordinal(),
                 d3.scale.linear())
             .xDomain(data.map(function(d) { return d.State; }))
-            .yDomain(fc.util.extent(series, function(d) { return 0; }, function(d) { return d.y + d.y0; }))
+            .yDomain(fc.util.extent()(series, function(d) { return 0; }, function(d) { return d.y + d.y0; }))
             .margin({right: 50, bottom: 50});
 
         var stackedBar = fc.series.stacked[seriesType]()


### PR DESCRIPTION
Also includes the `include` and `pad` methods. Note: `pad` will only scale number ranges, for the moment. If we want to implement scaling other types of range (e.g. `date`) then I see this as a separate issue.

Post review TODO list:
- [x] remove `d3.functior`
- [x] make use of `include`
- [x] try supporting `Date`, if it is easy to do