### PR TITLE
Added browserstack to visualTests. Closes #668.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,11 @@ module.exports = function(grunt) {
                     name: 'localhost',
                     port: 8000,
                     sslFlag: 0
+                },
+                {
+                    name: 'localhost',
+                    port: 9000,
+                    sslFlag: 0
                 }],
                 forcelocal: true,
                 onlyAutomate: true,
@@ -107,7 +112,8 @@ module.exports = function(grunt) {
             },
             visualTests: {
                 options: {
-                    base: 'visual-tests'
+                    base: 'visual-tests',
+                    port: 9000
                 }
             },
             site: {
@@ -300,11 +306,11 @@ module.exports = function(grunt) {
     grunt.registerTask('site:serve', ['connect:site', 'watch:site']);
 
     grunt.registerTask('webdriverTests:browserstack', browserstackKey ?
-        ['connect:site', 'browserstacktunnel-wrapper', 'webdriver'] : []);
+        ['connect:site', 'connect:visualTests', 'browserstacktunnel-wrapper', 'webdriver'] : []);
     grunt.registerTask('webdriverTests', ['eslint:webdriverTests', 'webdriverTests:browserstack']);
 
-    grunt.registerTask('ci', ['eslint:visualTests', 'components', 'uglify:components', 'site',
-        'uglify:site', 'webdriverTests']);
+    grunt.registerTask('ci', ['components', 'uglify:components', 'site',
+        'uglify:site', 'visualTests', 'webdriverTests']);
 
     grunt.registerTask('default', ['watch:components']);
 };

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install
 The following Grunt tasks, found in `Gruntfile.js`, can be run from the command line. The most commonly used tasks to build and develop the project are:
 
 - `grunt` - start a watcher which will automatically generate the project's JavaScript and CSS files in the _dist_ directory (at the root of the project) and run unit tests when files change.
-- `grunt visualTests:serve` - start a watcher which will automatically generate the visual tests and serve them at http://localhost:8000/ when files change.
+- `grunt visualTests:serve` - start a watcher which will automatically generate the visual tests and serve them at http://localhost:9000/ when files change.
 - `grunt site:serve` - start a watcher which will automatically generate the website and serve it at http://localhost:8000/ when files change.
 - `grunt ci` - the full build run by the CI server
 

--- a/webdriver-tests/visualTestsConsoleSpec.js
+++ b/webdriver-tests/visualTestsConsoleSpec.js
@@ -1,4 +1,3 @@
-
 describe('Visit all pages, check for no console errors', function() {
 
     function testPagesForConsoleOutput(urls, done) {
@@ -22,28 +21,8 @@ describe('Visit all pages, check for no console errors', function() {
             });
     }
 
-    function getLinks(baseUrl, cssSelector) {
-        return browser.url(baseUrl)
-            .getAttribute(cssSelector, 'href');
-    }
-
-    it('site documentation contains no logs / errors', function(done) {
-        return getLinks('http://localhost:8000/components/introduction/1-getting-started.html', '.nav-stacked a')
-            .then(function(links) {
-                return testPagesForConsoleOutput(links, done);
-            });
-    });
-
-    it('site examples contains no logs / errors', function(done) {
-        return getLinks('http://localhost:8000/examples', '.nav-stacked a')
-            .then(function(links) {
-                links.push('http://localhost:8000/examples');
-                return testPagesForConsoleOutput(links, done);
-            });
-    });
-
-    it('site main page contains no logs / errors', function(done) {
-        var links = ['http://localhost:8000/'];
+    it('visual tests contains no logs / errors', function(done) {
+        var links = ['http://localhost:9000/'];
         return testPagesForConsoleOutput(links, done);
     });
 });

--- a/webdriver-tests/wdio.conf.js
+++ b/webdriver-tests/wdio.conf.js
@@ -10,7 +10,6 @@ exports.config = {
             'browserstack.local': true
         }
     ],
-    baseUrl: 'http://localhost:8000',
     waitforTimeout: 100000,
     framework: 'jasmine',
     reporter: 'dot',


### PR DESCRIPTION
This is testing the visualTests now and running visualTests on the port 9000.

The testPagesForConsoleOutput function is duplicated, but I couldn't get the browserstack to correctly use it as a beforeEach or before in wdio.conf.js.

If anyone can fix it, please add a commit here, or fix in a later commit.