### PR TITLE
Convert svg.axes-container to g.axes-container

### DIFF
--- a/src/chart/cartesian.js
+++ b/src/chart/cartesian.js
@@ -84,11 +84,11 @@ export default function(xScale, yScale) {
                 <g class="plot-area-container"> \
                     <rect class="background" \
                         layout-style="position: absolute; top: 0; bottom: 0; left: 0; right: 0"/> \
-                    <svg class="axes-container" \
+                    <g class="axes-container" \
                         layout-style="position: absolute; top: 0; bottom: 0; left: 0; right: 0"> \
                         <g class="x-axis" layout-style="height: 0; width: 0"/> \
                         <g class="y-axis" layout-style="height: 0; width: 0"/> \
-                    </svg> \
+                    </g> \
                     <svg class="plot-area" \
                         layout-style="position: absolute; top: 0; bottom: 0; left: 0; right: 0"/> \
                 </g>');

--- a/src/fc.css
+++ b/src/fc.css
@@ -48,16 +48,8 @@ text {
   border-collapse: separate;
 }
 
-/* Increase .plot-area and .axes-container rule specificity to fix conflict
- with normalize's svg reset (svg:not(:root) { overflow: hidden; }). As
- normalize is used by bootstrap then there's a relatively large probability
- it's in the target page. */
-.plot-area-container>.plot-area {
+.plot-area {
   overflow: hidden;
-}
-
-.plot-area-container>.axes-container {
-  overflow: visible;
 }
 
 .y-axis .label,


### PR DESCRIPTION
Alternative fix for #737 

I kept thinking about the previous fix and I couldn't work out why the `.axes-container` needed to be an `svg` element. I've changed it to be a `g` and can't see any difference. Therefore, I've removed the CSS changes as well as removing the `overflow` rule for the element (as `g` elements don't have an `overflow` property)