### PR TITLE
Revert "Fix scale from center transition"

### DIFF
--- a/src/series/candlestick.js
+++ b/src/series/candlestick.js
@@ -19,12 +19,6 @@ export default function() {
         return 'translate(' + values.x + ', ' + values.yHigh + ')';
     }
 
-    function xScaleFromCenter(width, scale) {
-        var center = width / 2;
-        var offset = center - scale * center;
-        return 'matrix(' + scale + ', 0, 0, 1, ' + offset + ', 0)';
-    }
-
     var candlestick = function(selection) {
 
         selection.each(function(data, index) {
@@ -33,17 +27,14 @@ export default function() {
 
             var g = dataJoin(this, filteredData);
 
-            var barWidth = base.width(filteredData);
-
             g.enter()
                 .attr('transform', function(d, i) {
-                    return containerTranslation(base.values(d, i)) +
-                        xScaleFromCenter(barWidth, 1e-6);
+                    return containerTranslation(base.values(d, i)) + ' scale(1e-6, 1)';
                 })
                 .append('path');
 
             var pathGenerator = candlestickSvg()
-                .width(barWidth);
+                    .width(base.width(filteredData));
 
             g.each(function(d, i) {
 
@@ -52,10 +43,7 @@ export default function() {
                 var graph = d3.transition(d3.select(this))
                     .attr({
                         'class': 'candlestick ' + values.direction,
-                        'transform': function() {
-                            return containerTranslation(values) +
-                                xScaleFromCenter(barWidth, 1);
-                        }
+                        'transform': function() { return containerTranslation(values) + ' scale(1)'; }
                     });
 
                 pathGenerator.x(d3.functor(0))

--- a/src/series/ohlc.js
+++ b/src/series/ohlc.js
@@ -19,12 +19,6 @@ export default function(drawMethod) {
         return 'translate(' + values.x + ', ' + values.yHigh + ')';
     }
 
-    function xScaleFromCenter(width, scale) {
-        var center = width / 2;
-        var offset = center - scale * center;
-        return 'matrix(' + scale + ', 0, 0, 1, ' + offset + ', 0)';
-    }
-
     var ohlc = function(selection) {
         selection.each(function(data, index) {
 
@@ -32,17 +26,14 @@ export default function(drawMethod) {
 
             var g = dataJoin(this, filteredData);
 
-            var barWidth = base.width(filteredData);
-
             g.enter()
                 .attr('transform', function(d, i) {
-                    return containerTranslation(base.values(d, i)) +
-                        xScaleFromCenter(barWidth, 1e-6);
+                    return containerTranslation(base.values(d, i)) + ' scale(1e-6, 1)';
                 })
                 .append('path');
 
             var pathGenerator = svgOhlc()
-                    .width(barWidth);
+                    .width(base.width(filteredData));
 
             g.each(function(d, i) {
                 var values = base.values(d, i);
@@ -50,10 +41,7 @@ export default function(drawMethod) {
                 var graph = d3.transition(d3.select(this))
                     .attr({
                         'class': 'ohlc ' + values.direction,
-                        'transform': function() {
-                            return containerTranslation(values) +
-                                xScaleFromCenter(barWidth, 1);
-                        }
+                        'transform': function() { return containerTranslation(values) + ' scale(1)'; }
                     });
 
                 pathGenerator.x(d3.functor(0))


### PR DESCRIPTION
This reverts commit 684d0b0eab884d0dcbe134bf966fa54f1e1f94d8.

Fixes #774

I'm not sure the original fix was correct. When d3 transitions a transform it transitions the canonical translate, rotate, scale and skew. Hence the translation applied via the matrix was being combined with the translation that positions the candlestick, resulting in an odd transition.

If you look at the jsbin:

http://jsbin.com/zevagupaho/edit?html,js,output

then roll back to d3fc 4.3.0 you can see that the transitions were correct.

Were you testing this in a chart where the x-values were also scrolling at the same time?