### PR TITLE
Support jsnext:main

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A collection of components that make it easy to build interactive charts with D3",
   "author": "Scott Logic",
   "main": "dist/d3fc.js",
+  "jsnext:main": "src/fc.js",
   "dependencies": {
     "css-layout": "^1.1.0",
     "d3": "^3.5.4",


### PR DESCRIPTION
See https://github.com/rollup/rollup/wiki/jsnext:main
I have used this with some success in another project that has d3fc as a dependency and bundles using rollup. As it stands I think `fc.version` will be incorrect for the consumer, but it seems unlikely that anyone would want to rely on this property at runtime.