### PR TITLE
Callout

### DIFF
--- a/src/layout/callout.js
+++ b/src/layout/callout.js
@@ -1,0 +1,77 @@
+import d3 from 'd3';
+import {noop, identity} from '../util/fn';
+import {rebindAll} from '../util/rebind';
+import layoutRectangles from './rectangles';
+import arrayFunctor from '../util/arrayFunctor';
+
+export default function(layoutStrategy) {
+
+    var origin = d3.functor([0, 0]),
+        component = noop,
+        decorate = noop,
+        strategy = layoutStrategy || identity;
+
+    var rectangles = layoutRectangles(strategy);
+
+    var line = d3.svg.line()
+        .x(function(d) { return d[0]; })
+        .y(function(d) { return d[1]; });
+
+    var callout = function(data) {
+        var anchors = [];
+
+        // Define the two rebindAll exclusions
+        rectangles.anchor(function(i, x, y) {
+            anchors[i] = [x, y];
+        });
+
+        rectangles.component(function(selection) {
+
+            selection.append('path')
+                .attr('class', 'callout-path')
+                .attr('d', function(d, i) {
+                    // Since the rectangle changes placement, offset
+                    // that placement so the origin point is fixed
+                    var pointOrigin = origin(d, i).map(function(value, dimension) {
+                        return anchors[i][dimension] + value;
+                    });
+                    return line([anchors[i], pointOrigin]);
+                });
+
+            selection.append('rect')
+                .attr('class', 'callout-label')
+                .layout({
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    bottom: 0,
+                    right: 0
+                });
+
+            decorate(selection);
+            selection.layout();
+        });
+
+        rectangles.call(this, data);
+    };
+
+    rebindAll(callout, rectangles, '', ['anchor', 'component']);
+
+    callout.origin = function(x) {
+        if (!arguments.length) {
+            return origin;
+        }
+        origin = x;
+        return callout;
+    };
+
+    callout.decorate = function(x) {
+        if (!arguments.length) {
+            return decorate;
+        }
+        decorate = x;
+        return callout;
+    };
+
+    return callout;
+}

--- a/src/layout/callout.js
+++ b/src/layout/callout.js
@@ -18,11 +18,15 @@ export default function(layoutStrategy) {
         .y(function(d) { return d[1]; });
 
     var callout = function(data) {
+        // Define the rebindAll exclusions
         var anchors = [];
-
-        // Define the two rebindAll exclusions
         rectangles.anchor(function(i, x, y) {
             anchors[i] = [x, y];
+        });
+
+        var translates = [];
+        rectangles.translate(function(i, x, y) {
+            translates[i] = [x, y];
         });
 
         rectangles.component(function(selection) {
@@ -33,7 +37,7 @@ export default function(layoutStrategy) {
                     // Since the rectangle changes placement, offset
                     // that placement so the origin point is fixed
                     var pointOrigin = origin(d, i).map(function(value, dimension) {
-                        return anchors[i][dimension] + value;
+                        return value - translates[i][dimension];
                     });
                     return line([anchors[i], pointOrigin]);
                 });
@@ -55,7 +59,7 @@ export default function(layoutStrategy) {
         rectangles.call(this, data);
     };
 
-    rebindAll(callout, rectangles, '', ['anchor', 'component']);
+    rebindAll(callout, rectangles, '', ['anchor', 'translate', 'component']);
 
     callout.origin = function(x) {
         if (!arguments.length) {

--- a/src/layout/layout.js
+++ b/src/layout/layout.js
@@ -1,7 +1,9 @@
 import rectangles from './rectangles';
+import callout from './callout';
 import strategy from './strategy/strategy';
 
 export default {
+    callout: callout,
     rectangles: rectangles,
     strategy: strategy
 };

--- a/src/layout/rectangles.js
+++ b/src/layout/rectangles.js
@@ -13,6 +13,7 @@ export default function(layoutStrategy) {
     var xScale = d3.scale.identity(),
         yScale = d3.scale.identity(),
         anchor = noop,
+        translate = noop,
         strategy = layoutStrategy || identity,
         component = noop;
 
@@ -59,6 +60,8 @@ export default function(layoutStrategy) {
 
             data.forEach(function(d, i) {
                 var pos = position(d, i);
+                var offset = layout[i];
+                translate(i, offset.x, offset.y);
                 anchor(i, pos[0] - layout[i].x, pos[1] - layout[i].y);
             });
 
@@ -95,6 +98,14 @@ export default function(layoutStrategy) {
             return anchor;
         }
         anchor = x;
+        return rectangles;
+    };
+
+    rectangles.translate = function(x) {
+        if (!arguments.length) {
+            return translate;
+        }
+        translate = x;
         return rectangles;
     };
 

--- a/visual-tests/index.html
+++ b/visual-tests/index.html
@@ -284,6 +284,11 @@
               <p>Demonstrates the rectangle layout component.</p>
             </article>
 
+            <article data-href="layout/callout.html">
+              <h3>Callout</h3>
+              <p>Demonstrates the callout component.</p>
+            </article>
+
             <article data-href="layout/layoutProgrammatic.html">
               <h3>Layout Programmatic</h3>
               <p>Constructs a layout programmatically.</p>

--- a/visual-tests/layout/callout.html
+++ b/visual-tests/layout/callout.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Callout - d3fc Visual Tests</title>
+    <link href="../assets/d3fc.css" rel="stylesheet">
+  </head>
+  <body>
+    <div id="tooltip" style="float: left;"></div>
+    <div id="strategies" style="float: right;">
+      Use Strategy:
+      <p>
+        <input type="radio" id="noop" name="strategy" value="noop" checked>
+        <label for="noop">No-op</label>
+      </p>
+      <p>
+        <input type="radio" id="bounding-box" name="strategy" value="bounding-box">
+        <label for="bounding-box">Bounding Box</label>
+      </p>
+      <p>
+        <input type="radio" id="greedy" name="strategy" value="greedy">
+        <label for="greedy">Greedy</label>
+      </p>
+      <p>
+        <input type="radio" id="local" name="strategy" value="local">
+        <label for="local">Local</label>
+      </p>
+      <p>
+        <input type="radio" id="annealing" name="strategy" value="annealing">
+        <label for="annealing">Annealing</label>
+      </p>
+    </div>
+    <footer>
+      <script src="../assets/d3.js"></script>
+      <script src="../assets/css-layout.js"></script>
+      <script src="../assets/d3fc.js"></script>
+      <script src="../assets/seedrandom.min.js"></script>
+      <script src="../setup.js"></script>
+      <script src="callout.js"></script>
+      <script src="//localhost:36729/livereload.js"></script>
+    </footer>
+  </body>
+</html>

--- a/visual-tests/layout/callout.js
+++ b/visual-tests/layout/callout.js
@@ -1,0 +1,107 @@
+(function(d3, fc) {
+    'use strict';
+
+    // a very simple example component
+    function decorator(selection) {
+        selection.append('text')
+            .text(function(d, index) { return d.data; })
+            .attr({'y': 18, 'x': 20});
+    }
+
+    var data = [
+        { x: 100, y: 100, data: 'hi'},
+        { x: 50, y: 100, data: 'hello'},
+        { x: 20, y: 75, data: 'W0Ot'},
+        { x: 250, y: 200, data: 'Welcome'}
+    ];
+
+    var width = 600, height = 250;
+    var itemWidth = 100, itemHeight = 30;
+    var anchors = [];
+
+    // Add some more data
+    for (var i = 0; i < 20; i++) {
+        data.push({
+            x: i * 30,
+            y: (i * i * i) % height,
+            data: i
+        });
+    }
+
+    var calloutAnchors = [];
+    for (var j = 0; j < data.length; j++) {
+        calloutAnchors.push([-20, 10]);
+    }
+
+    var svg = d3.select('#tooltip')
+        .append('svg')
+        .attr('width', width)
+        .attr('height', height);
+
+    var xScale = d3.scale.linear()
+        .range([0, width]);
+
+    var yScale = d3.scale.linear()
+        .range([height, 0]);
+
+    function useStrategy(strategyToUse) {
+        var smart = fc.layout.callout(strategyToUse)
+            .xScale(xScale)
+            .yScale(yScale)
+            .size([itemWidth, itemHeight])
+            .origin(function(d, index) {
+                return calloutAnchors[index];
+            })
+            .decorate(decorator);
+
+        svg.selectAll('g').remove();
+
+        svg.datum(data)
+            .call(smart);
+    }
+
+    var greedyStrategy = fc.layout.strategy.greedy()
+        .containerWidth(width)
+        .containerHeight(height);
+
+    var boundingBox = fc.layout.strategy.boundingBox()
+        .containerWidth(width)
+        .containerHeight(height);
+
+    var local = fc.layout.strategy.local()
+        .containerWidth(width)
+        .containerHeight(height)
+        .iterations(10);
+
+    var annealing = fc.layout.strategy.annealing()
+        .containerWidth(width)
+        .containerHeight(height);
+
+    useStrategy(null);
+
+    document.getElementById('noop')
+        .addEventListener('change', function() {
+            useStrategy(null);
+        });
+
+    document.getElementById('bounding-box')
+        .addEventListener('change', function() {
+            useStrategy(boundingBox);
+        });
+
+    document.getElementById('greedy')
+        .addEventListener('change', function() {
+            useStrategy(greedyStrategy);
+        });
+
+    document.getElementById('local')
+        .addEventListener('change', function() {
+            useStrategy(local);
+        });
+
+    document.getElementById('annealing')
+        .addEventListener('change', function() {
+            useStrategy(annealing);
+        });
+
+})(d3, fc);

--- a/visual-tests/layout/callout.js
+++ b/visual-tests/layout/callout.js
@@ -17,7 +17,6 @@
 
     var width = 600, height = 250;
     var itemWidth = 100, itemHeight = 30;
-    var anchors = [];
 
     // Add some more data
     for (var i = 0; i < 20; i++) {
@@ -30,7 +29,7 @@
 
     var calloutAnchors = [];
     for (var j = 0; j < data.length; j++) {
-        calloutAnchors.push([-20, 10]);
+        calloutAnchors.push([width / 2, height / 2]);
     }
 
     var svg = d3.select('#tooltip')


### PR DESCRIPTION
Implements a callout in `fc.layout.callout`, using flexbox layout.

Set-up should be done by providing a strategy to use, and an `origin` accessor function to indicate where the data is on the chart that the callout should point to (optional). Data provided in the main function call should be in the same format as in `fc.layout.rectangles` in that it's an array of objects of `x, y, width, height` for where the label of the callout should be located. Further decoration, such as text placement, is done using `decorate`.