### PR TITLE
New interface for random.financial

### DIFF
--- a/site/src/components/data/financial-example.js
+++ b/site/src/components/data/financial-example.js
@@ -1,7 +1,18 @@
-var dataGenerator = fc.data.random.financial();
+var financial = fc.data.random.financial()
+  .startDate(new Date(2016, 0, 1))
+  .startPrice(100)
+  .granularity(60 * 60 * 24) // Period in seconds between dates, by default 86400 (1 day).
+  .steps(10)                 // Steps provided to random.walk. Higher = slower, more accurate simulation.
+  .mu(0.1)                   // Drift provided to random.walk (calendar year units)
+  .sigma(0.1)                // Volatility provided to random.walk (calendar year units).
+  .volume(100)               // Volume of each point. Can be either a number or function(datum).
+  .filter(function(d) {      // Include points satisfying a condition, by default include all.
+      return true;
+  });
+
 
 // generate some data!
-var data = dataGenerator(5);
+var data = financial(2);
 
 d3.select('#financial')
   .text(JSON.stringify(data, null, 2));

--- a/site/src/components/data/financial-example.js
+++ b/site/src/components/data/financial-example.js
@@ -1,13 +1,13 @@
 var financial = fc.data.random.financial()
   .startDate(new Date(2016, 0, 1))
   .startPrice(100)
-  .interval(d3.time.day)     // d3 time interval function, by default, d3.time.day.
+  .interval(d3.time.day)     // d3 time interval function, d3.time.day by default.
   .intervalStep(1)           // Integer number of intervals that points should have dates offset by. Default 1.
   .steps(10)                 // Steps provided to random.walk. Higher = slower, more accurate simulation.
   .mu(0.1)                   // Drift provided to random.walk.
   .sigma(0.1)                // Volatility provided to random.walk.
-  .unitInterval(d3.time.day) // Unit choice for mu and sigma (interval). By default d3.time.year
-  .unitStep(252)             // Unit choice for mu and sigma (Integer number of intervals), by default 1.
+  .unitInterval(d3.time.day) // Unit choice for mu and sigma (d3 time interval). d3.time.year by default.
+  .unitIntervalStep(252)     // Unit choice for mu and sigma (integer number of intervals), by default 1.
   .volume(100)               // Volume of each point. Can be either a number or function(datum).
   .filter(function(d) {      // Include points satisfying a condition, by default include all.
       return true;

--- a/site/src/components/data/financial-example.js
+++ b/site/src/components/data/financial-example.js
@@ -1,10 +1,13 @@
 var financial = fc.data.random.financial()
   .startDate(new Date(2016, 0, 1))
   .startPrice(100)
-  .granularity(60 * 60 * 24) // Period in seconds between dates, by default 86400 (1 day).
+  .interval(d3.time.day)     // d3 time interval function, by default, d3.time.day.
+  .intervalStep(1)           // Integer number of intervals that points should have dates offset by. Default 1.
   .steps(10)                 // Steps provided to random.walk. Higher = slower, more accurate simulation.
-  .mu(0.1)                   // Drift provided to random.walk (calendar year units)
-  .sigma(0.1)                // Volatility provided to random.walk (calendar year units).
+  .mu(0.1)                   // Drift provided to random.walk.
+  .sigma(0.1)                // Volatility provided to random.walk.
+  .unitInterval(d3.time.day) // Unit choice for mu and sigma (interval). By default d3.time.year
+  .unitStep(252)             // Unit choice for mu and sigma (Integer number of intervals), by default 1.
   .volume(100)               // Volume of each point. Can be either a number or function(datum).
   .filter(function(d) {      // Include points satisfying a condition, by default include all.
       return true;

--- a/site/src/components/data/financial-stream-example.html
+++ b/site/src/components/data/financial-stream-example.html
@@ -1,2 +1,2 @@
-<button id='financial-stream-next'>Add point using stream.next()</button> <button id='financial-stream-take'>Add 2 points using stream.take(2)</button> <button id='financial-stream-until'>Add points until date >= 2016-01-15</button> <button id='financial-stream-reset'>Reset</button>
+<button id='financial-stream-next'>Add point using stream.next()</button> <button id='financial-stream-take'>Add 2 points using stream.take(2)</button> <button id='financial-stream-until'>Add points until date > 2016-01-15</button> <button id='financial-stream-reset'>Reset</button>
 <pre id='financial-stream'></pre>

--- a/site/src/components/data/financial-stream-example.html
+++ b/site/src/components/data/financial-stream-example.html
@@ -1,0 +1,2 @@
+<button id='financial-stream-next'>Add point using stream.next()</button> <button id='financial-stream-take'>Add 2 points using stream.take(2)</button> <button id='financial-stream-until'>Add points until date >= 2016-01-15</button> <button id='financial-stream-reset'>Reset</button>
+<pre id='financial-stream'></pre>

--- a/site/src/components/data/financial-stream-example.js
+++ b/site/src/components/data/financial-stream-example.js
@@ -16,7 +16,7 @@ d3.select('#financial-stream-take').on('click', function() {
     update();
 });
 d3.select('#financial-stream-until').on('click', function() {
-    data = data.concat(stream.until(function(d) { return d.date >= new Date(2016, 0, 15); }));
+    data = data.concat(stream.until(function(d) { return d.date > new Date(2016, 0, 15); }));
     update();
 });
 d3.select('#financial-stream-reset').on('click', function() {

--- a/site/src/components/data/financial-stream-example.js
+++ b/site/src/components/data/financial-stream-example.js
@@ -1,0 +1,38 @@
+var financial = fc.data.random.financial()
+    .startDate(new Date(2016, 0, 1))
+    .startPrice(100)
+    .granularity(60 * 60 * 24);
+
+var stream = financial.stream();
+var data = [];
+
+d3.select('#financial-stream-next').on('click', function() {
+    data.push(stream.next());
+    update();
+});
+d3.select('#financial-stream-take').on('click', function() {
+    data = data.concat(stream.take(2));
+    update();
+});
+d3.select('#financial-stream-until').on('click', function() {
+    data = data.concat(stream.until(function(d) { return d.date >= new Date(2016, 0, 15); }));
+    update();
+});
+d3.select('#financial-stream-reset').on('click', function() {
+    reset();
+    update();
+});
+
+function reset() {
+    stream = financial.stream();
+    data = [];
+}
+
+function update() {
+    var text = 'data.length: ' + data.length + '\n';
+    text += JSON.stringify(data, null, 2);
+    d3.select('#financial-stream')
+        .text(text);
+}
+
+update();

--- a/site/src/components/data/financial-stream-example.js
+++ b/site/src/components/data/financial-stream-example.js
@@ -1,7 +1,8 @@
 var financial = fc.data.random.financial()
     .startDate(new Date(2016, 0, 1))
     .startPrice(100)
-    .granularity(60 * 60 * 24);
+    .interval(d3.time.day)
+    .intervalStep(1);
 
 var stream = financial.stream();
 var data = [];

--- a/site/src/components/data/financial.md
+++ b/site/src/components/data/financial.md
@@ -10,7 +10,7 @@ externals:
   financial-stream-example-html: financial-stream-example.html
 ---
 
-The random financial data generator component generates open-high-low-close-volume financial data. 
+The random financial data generator component generates open-high-low-close-volume financial data.
 Prices are calculated using the [random walk](./walk.html) component.
 A `filter` can be supplied to exclude points from the output. 
 Pre-defined filters can be used, for example to skip weekends use `fc.data.random.filter.skipWeekends`.
@@ -31,10 +31,12 @@ Generates the following:
 {{{ dynamic-include 'codepen' html="financial-example-html" js="financial-example-js" }}}
 
 ## Stream
-The component exposes a stateful streaming interface.
+If you need to make successive calls to generate data while keeping track of the latest date and price, 
+use the streaming interface.
 You can see this in action in the [streaming chart example](../../examples/streaming/index.html).
-First create a stream from a random.financial instance with `financial.stream()`.
-Data points can then be generated using the stream's `next`, `take`, and `until` methods — the stream will use the latest date and price for subsequent calls.
+First create a stream from an instance of `fc.data.random.financial` by calling the `stream` method.
+Data points can then be generated using the stream's `next`, `take`, and `until` methods 
+— the stream will use the latest date and price for subsequent calls.
 
 An example using `next`, `take` and `until`:
 

--- a/site/src/components/data/financial.md
+++ b/site/src/components/data/financial.md
@@ -6,9 +6,14 @@ namespace: Data
 externals:
   financial-example-js: financial-example.js
   financial-example-html: financial-example.html
+  financial-stream-example-js: financial-stream-example.js
+  financial-stream-example-html: financial-stream-example.html
 ---
 
-The random financial data generator component is a useful testing utility that generates data via a random walk algorithm.
+The random financial data generator component generates open-high-low-close-volume financial data. 
+Prices are calculated using the [random walk](./walk.html) component.
+A `filter` can be supplied to exclude points from the output. 
+Pre-defined filters can be used, for example to skip weekends use `fc.data.random.filter.skipWeekends`.
 
 The following example:
 
@@ -18,11 +23,28 @@ The following example:
 
 Generates the following:
 
-{{{ dynamic-include 'codepen' html="financial-example-html" js="financial-example-js" }}}
-
 {{{financial-example-html}}}
 <script type="text/javascript">
 {{{financial-example-js}}}
-</script>
+</script> 
 
-A `filter` can be supplied to skips other days, or change the start price, volume and date. Pre-defined filters can be used, for example to skip weekends use `fc.data.random.filter.skipWeekends`.
+{{{ dynamic-include 'codepen' html="financial-example-html" js="financial-example-js" }}}
+
+## Stream
+The component exposes a stateful streaming interface.
+You can see this in action in the [streaming chart example](../../examples/streaming/index.html).
+First create a stream from a random.financial instance with `financial.stream()`.
+Data points can then be generated using the stream's `next`, `take`, and `until` methods — the stream will use the latest date and price for subsequent calls.
+
+An example using `next`, `take` and `until`:
+
+```js
+{{{ codeblock financial-stream-example-js}}}
+```
+
+{{{financial-stream-example-html}}}
+<script type="text/javascript">
+{{{financial-stream-example-js}}}
+</script> 
+
+{{{ dynamic-include 'codepen' html="financial-stream-example-html" js="financial-stream-example-js" }}}

--- a/site/src/components/data/walk-example.js
+++ b/site/src/components/data/walk-example.js
@@ -1,11 +1,11 @@
-var dataGenerator = fc.data.random.walk()
+var walk = fc.data.random.walk()
   .period(2)   // Projection period, by default = 1
-  .steps(30)   // Number of points to generate, by default = 20
+  .steps(30)   // Number of steps to take, by default = 20
   .mu(0.3)     // Drift component, by default = 0.1
   .sigma(0.2); // Volatility, by default = 0.1
 
-// data is generated here
-var data = dataGenerator(100); // The series starts at 100
+// generate some data!
+var data = walk(100); // The series starts at 100
 
 d3.select('#walk')
   .text(JSON.stringify(data, null, 2));

--- a/site/src/components/data/walk.md
+++ b/site/src/components/data/walk.md
@@ -8,8 +8,8 @@ externals:
   walk-example-html: walk-example.html
 ---
 
-The random walk component creates a random series of values based on a [Geometric Brownian Motion](http://stuartreid.co.za/interactive-stochastic-processes/). It
-is useful for generating arbitrary sets of data. The [random financial](./financial.html) component uses this component to create a random price series and a random volume series.
+The random walk component creates a series of values based on the [Geometric Brownian Motion](http://stuartreid.co.za/interactive-stochastic-processes/) stochastic process.
+The [random financial](./financial.html) component uses it to create random open-high-low-close (OHLC) price data.
 
 ```js
 {{{walk-example-js}}}

--- a/site/src/examples/basecoin/base-coin.js
+++ b/site/src/examples/basecoin/base-coin.js
@@ -252,7 +252,8 @@
         return d;
     }
 
-    var _data = dataGenerator(300)
+    var stream = dataGenerator.stream();
+    var _data = stream.take(300)
         .map(enhanceDataItem);
 
     var frame = 0;
@@ -262,7 +263,7 @@
     function render() {
         frameTimings.push(performance.now());
 
-        var datum = dataGenerator(1)[0];
+        var datum = stream.next();
         datum = enhanceDataItem(datum, _data.length + frame, _data);
 
         // Roll the data buffer

--- a/site/src/examples/streaming/streaming.js
+++ b/site/src/examples/streaming/streaming.js
@@ -1,11 +1,10 @@
 // create some test data
-var generator = fc.data.random.financial();
-var data = generator(110);
+var stream = fc.data.random.financial().stream();
+var data = stream.take(110);
 
 function renderChart() {
     // add a new datapoint and remove an old one
-    var datum = generator(1)[0];
-    data.push(datum);
+    data.push(stream.next());
     data.shift();
 
     // compute the bollinger bands

--- a/src/data/random/filter/skipWeekends.js
+++ b/src/data/random/filter/skipWeekends.js
@@ -1,6 +1,6 @@
 export function skipWeekends() {
-    return function(date) {
-        var day = date.getDay();
+    return function(datum) {
+        var day = datum.date.getDay();
         return !(day === 0 || day === 6);
     };
 }

--- a/src/data/random/financial.js
+++ b/src/data/random/financial.js
@@ -4,22 +4,25 @@ import d3 from 'd3';
 export default function() {
     var startDate = new Date();
     var startPrice = 100;
-    var granularity = 60 * 60 * 24;
+    var interval = d3.time.day;
+    var intervalStep = 1;
+    var unitInterval = d3.time.year;
+    var unitStep = 1;
     var filter = null;
     var volume = function() {
         var randomNormal = d3.random.normal(1, 0.1);
-        return Math.ceil(randomNormal() * granularity);
+        return Math.ceil(randomNormal() * 1000);
     };
     var walk = _walk();
 
-    function granularityInYears() {
-        var millisecondsPerYear = 3.15569e10;
-        return (granularity * 1000) / millisecondsPerYear;
+    function getOffsetPeriod(date) {
+        var unitMilliseconds = unitInterval.offset(date, unitStep) - date;
+        return (interval.offset(date, intervalStep) - date) / unitMilliseconds;
     }
 
     function calculateOHLC(start, price) {
-        var prices = walk
-            .period(granularityInYears())(price);
+        var period = getOffsetPeriod(start);
+        var prices = walk.period(period)(price);
         var datum = {
             date: start,
             open: prices[0],
@@ -44,7 +47,7 @@ export default function() {
             if (!latest) {
                 latest = calculateOHLC(new Date(startDate.getTime()), startPrice);
             } else {
-                latest = calculateOHLC(new Date(latest.date.getTime() + granularity * 1000), latest.close);
+                latest = calculateOHLC(interval.offset(latest.date, intervalStep), latest.close);
             }
             return latest;
         }
@@ -102,11 +105,32 @@ export default function() {
         startPrice = x;
         return financial;
     };
-    financial.granularity = function(x) {
+    financial.interval = function(x) {
         if (!arguments.length) {
-            return granularity;
+            return interval;
         }
-        granularity = x;
+        interval = x;
+        return financial;
+    };
+    financial.intervalStep = function(x) {
+        if (!arguments.length) {
+            return intervalStep;
+        }
+        intervalStep = x;
+        return financial;
+    };
+    financial.unitInterval = function(x) {
+        if (!arguments.length) {
+            return unitInterval;
+        }
+        unitInterval = x;
+        return financial;
+    };
+    financial.unitStep = function(x) {
+        if (!arguments.length) {
+            return unitStep;
+        }
+        unitStep = x;
         return financial;
     };
     financial.filter = function(x) {

--- a/src/data/random/financial.js
+++ b/src/data/random/financial.js
@@ -53,7 +53,7 @@ export default function() {
         }
         function getNextDatum() {
             var ohlc = getDatum();
-            while (filter && !filter(ohlc.date)) {
+            while (filter && !filter(ohlc)) {
                 ohlc = getDatum();
             }
             return ohlc;

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,16 +1,11 @@
 {
     "env": {
-        "browser": true
+        "browser": true,
+        "jasmine": true
     },
     "globals": {
-        "expect": true,
         "fc": true,
-        "it": true,
-        "describe": true,
         "d3": true,
-        "beforeEach": true,
-        "jasmine": true,
-        "spyOn": true
     },
     "rules": {
     }

--- a/tests/data/random/financialSpec.js
+++ b/tests/data/random/financialSpec.js
@@ -1,49 +1,95 @@
 describe('fc.data.random.financial', function() {
 
-    describe('without filter', function() {
-        var dataGenerator;
-
-        beforeEach(function() {
-            dataGenerator = fc.data.random.financial();
-        });
-
-        it('should return data for the requested number of days', function() {
-            expect(dataGenerator(10).length)
-                .toEqual(10);
-        });
-        it('should return an initial open value equal to the set startPrice', function() {
-            dataGenerator.startPrice(50);
-            expect(dataGenerator(10)[0].open)
-                .toEqual(50);
-        });
-        it('should return an initial volume equal to the set startVolume', function() {
-            dataGenerator.startVolume(100);
-            expect(dataGenerator(10)[0].volume)
-                .toEqual(100);
-        });
+    var generator;
+    beforeEach(function() {
+        generator = fc.data.random.financial()
+            .startDate(new Date(2015, 0, 1))
+            .granularity(60 * 60 * 24);
     });
 
-    describe('with filter', function() {
-        var dataGenerator;
+    it('should return the correct number of data points', function() {
+        var result = generator(10);
+        expect(result.length).toBe(10);
+    });
 
-        beforeEach(function() {
-            dataGenerator = fc.data.random.financial()
-                .filter(fc.data.random.filter.skipWeekends());
+    it('should always return an initial date equal to the set startDate', function() {
+        var result0 = generator(10);
+        var result1 = generator(10);
+        expect(result0[0].date).toEqual(new Date(2015, 0, 1));
+        expect(result1[0].date).toEqual(new Date(2015, 0, 1));
+    });
+
+    it('should always return an initial open value equal to the set startPrice', function() {
+        generator.startPrice(50);
+        var result0 = generator(10);
+        var result1 = generator(10);
+        expect(result0[0].open).toEqual(50);
+        expect(result1[0].open).toEqual(50);
+    });
+
+    it('should exclude points with filtered date from result', function() {
+        generator.filter(function(date) {
+            return date > new Date(2015, 0, 5);
         });
+        var stream = generator.stream();
+        var result = stream.until(function(datum) { return datum.date > new Date(2015, 0, 10); });
+        expect(result.length).toBe(5);
+    });
 
-        it('should not include weekends', function() {
-            var data = dataGenerator(10);
+    it('with fc.data.random.filter.skipWeekends filter, should not include weekends', function() {
+        generator.filter(fc.data.random.filter.skipWeekends());
+        var data = generator(10);
+        for (var i = 0, max = data.length; i < max; i += 1) {
+            var day = data[i].date.getDay();
+            expect(day).not.toBe(0);
+            expect(day).not.toBe(6);
+        }
+    });
 
-            for (var i = 0, max = data.length; i < max; i += 1) {
-                var day = data[i].date.getDay();
-                expect(day).not.toBe(0);
-                expect(day).not.toBe(6);
-            }
+    it('stream.next should initially return datum at start date', function() {
+        var stream = generator.stream();
+        var datum = stream.next();
+        expect(datum.date).toEqual(new Date(2015, 0, 1));
+    });
+
+    it('stream.next should subsequently return datum with date incremented by set granularity', function() {
+        var stream = generator.stream();
+        stream.next();
+        var datum = stream.next();
+        expect(datum.date).toEqual(new Date(2015, 0, 2));
+    });
+
+    it('stream.next with filter should skip filtered dates', function() {
+        generator.filter(function(date) {
+            return date > new Date(2015, 0, 4) && date.getTime() !== new Date(2015, 0, 6).getTime();
         });
+        var stream = generator.stream();
+        var first = stream.next();
+        var second = stream.next();
+        expect(first.date).toEqual(new Date(2015, 0, 5));
+        expect(second.date).toEqual(new Date(2015, 0, 7));
+    });
 
-        it('should return data for the requested number of days', function() {
-            expect(dataGenerator(10).length)
-                .toEqual(10);
+    it('stream.take should return the requested number of points', function() {
+        generator.filter(function(date) {
+            return date > new Date(2015, 0, 5);
         });
+        var stream = generator.stream();
+        var data = stream.take(10);
+        expect(data.length).toBe(10);
+    });
+
+    it('stream.take with non-positive numeric argument should return empty array', function() {
+        var stream = generator.stream();
+        var data0 = stream.take(0);
+        expect(data0.length).toBe(0);
+        var data1 = stream.take(-1);
+        expect(data1.length).toBe(0);
+    });
+
+    it('stream.until should append generated datums to returned array until datum satisfies specified condition', function() {
+        var stream = generator.stream();
+        var data = stream.until(function(d) { return d.date > new Date(2015, 0, 10); });
+        expect(data.length).toBe(10);
     });
 });

--- a/tests/data/random/financialSpec.js
+++ b/tests/data/random/financialSpec.js
@@ -33,7 +33,7 @@ describe('fc.data.random.financial', function() {
             return d.date > new Date(2015, 0, 5);
         });
         var stream = generator.stream();
-        var result = stream.until(function(datum) { return datum.date >= new Date(2015, 0, 10); });
+        var result = stream.until(function(datum) { return datum.date > new Date(2015, 0, 10); });
         expect(result.length).toBe(5);
     });
 
@@ -107,33 +107,28 @@ describe('fc.data.random.financial', function() {
         expect(data1.length).toBe(0);
     });
 
-    it('stream.until should generate data up to and including the datum that satisfies the specified condition', function() {
+    it('stream.take with undefined argument should return empty array', function() {
         var stream = generator.stream();
-        var data = stream.until(function(d) { return d.date >= new Date(2015, 0, 10); });
+        var data = stream.take();
+        expect(data.length).toBe(0);
+    });
+
+    it('stream.until should generate data up to the datum that satisfies the specified condition', function() {
+        var stream = generator.stream();
+        var data = stream.until(function(d) { return d.date > new Date(2015, 0, 10); });
         expect(data.length).toBe(10);
     });
 
     it('stream.until subsequent stream method call should have correctly incremented date', function() {
         var stream = generator.stream();
-        stream.until(function(d) { return d.date >= new Date(2015, 0, 10); });
+        stream.until(function(d) { return d.date > new Date(2015, 0, 10); });
         var next = stream.next();
         expect(next.date).toEqual(new Date(2015, 0, 11));
     });
 
-    it('stream.until should return empty array if latest datum already satisfies condition and should not increment latest', function() {
-        var stream = generator.stream();
-        stream.take(10);
-        var data = stream.until(function(d) { return d.date >= new Date(2015, 0, 10); });
-        var next = stream.next();
-        expect(data).toEqual([]);
-        expect(next.date).toEqual(new Date(2015, 0, 11));
-    });
-
-    it('stream.until without comparison should return empty array and should not increment latest', function() {
+    it('stream.until without comparison should return empty array', function() {
         var stream = generator.stream();
         var data = stream.until();
-        var next = stream.next();
         expect(data).toEqual([]);
-        expect(next.date).toEqual(new Date(2015, 0, 1));
     });
 });

--- a/tests/data/random/financialSpec.js
+++ b/tests/data/random/financialSpec.js
@@ -4,7 +4,8 @@ describe('fc.data.random.financial', function() {
     beforeEach(function() {
         generator = fc.data.random.financial()
             .startDate(new Date(2015, 0, 1))
-            .granularity(60 * 60 * 24);
+            .interval(d3.time.day)
+            .intervalStep(1);
     });
 
     it('should return the correct number of data points', function() {

--- a/tests/data/random/financialSpec.js
+++ b/tests/data/random/financialSpec.js
@@ -28,8 +28,8 @@ describe('fc.data.random.financial', function() {
     });
 
     it('should exclude points with filtered date from result', function() {
-        generator.filter(function(date) {
-            return date > new Date(2015, 0, 5);
+        generator.filter(function(d) {
+            return d.date > new Date(2015, 0, 5);
         });
         var stream = generator.stream();
         var result = stream.until(function(datum) { return datum.date > new Date(2015, 0, 10); });
@@ -60,8 +60,8 @@ describe('fc.data.random.financial', function() {
     });
 
     it('stream.next with filter should skip filtered dates', function() {
-        generator.filter(function(date) {
-            return date > new Date(2015, 0, 4) && date.getTime() !== new Date(2015, 0, 6).getTime();
+        generator.filter(function(d) {
+            return d.date > new Date(2015, 0, 4) && d.date.getTime() !== new Date(2015, 0, 6).getTime();
         });
         var stream = generator.stream();
         var first = stream.next();
@@ -71,8 +71,8 @@ describe('fc.data.random.financial', function() {
     });
 
     it('stream.take should return the requested number of points', function() {
-        generator.filter(function(date) {
-            return date > new Date(2015, 0, 5);
+        generator.filter(function(d) {
+            return d.date > new Date(2015, 0, 5);
         });
         var stream = generator.stream();
         var data = stream.take(10);

--- a/tests/series/candlestickSpec.js
+++ b/tests/series/candlestickSpec.js
@@ -4,8 +4,7 @@ describe('candlestick', function() {
 
     beforeEach(function() {
         element = document.createElement('svg');
-        data = fc.data.random.financial()
-            .filter(function() { return true; })(10);
+        data = fc.data.random.financial()(10);
     });
 
     it('should render a path for each datapoint', function() {

--- a/tests/series/ohlcSpec.js
+++ b/tests/series/ohlcSpec.js
@@ -4,8 +4,7 @@ describe('ohlc', function() {
 
     beforeEach(function() {
         element = document.createElement('svg');
-        data = fc.data.random.financial()
-            .filter(function() { return true; })(10);
+        data = fc.data.random.financial()(10);
     });
 
     it('should render a path for each datapoint', function() {

--- a/visual-tests/functional/update.js
+++ b/visual-tests/functional/update.js
@@ -3,7 +3,8 @@
 
     var generator = fc.data.random.financial()
         .startDate(new Date(2014, 1, 1));
-    var data = generator(20);
+    var stream = generator.stream();
+    var data = stream.take(20);
 
     var key = function(d) { return d.date; };
 
@@ -58,11 +59,7 @@
       .yScale(priceScale);
 
     setInterval(function() {
-        var datum;
-        while (!datum) {
-            datum = generator(1)[0];
-        }
-        data.push(datum);
+        data.push(stream.next());
         data.shift();
         data.forEach(function(d) {
             d.low = d.low - 0.1;


### PR DESCRIPTION
* Implements the interface discussed in #763, allowing for controlling the time increment #754.
Time increment is provided as a number of seconds, not a d3 time interval - it's not possible to create a d3 time interval of 5 mins, for example.
* Replaces volume model with something simpler, and makes it configurable as a functor property.
* Component function now does not mutate state - stateful usage is provided by the closure returned from `generator.stream()`, as proposed.

Todo:
- [x] Convert usages
- [x] Improve documentation