### PR TITLE
Maintain crosshair pointer while zooming with mouse wheel [fixes #836]

### DIFF
--- a/src/tool/crosshair.js
+++ b/src/tool/crosshair.js
@@ -56,6 +56,7 @@ export default function() {
                 .style('pointer-events', 'all')
                 .on('mouseenter.crosshair', mouseenter)
                 .on('mousemove.crosshair', mousemove)
+                .on('wheel.crosshair', mousewheel)
                 .on('mouseleave.crosshair', mouseleave);
 
             var overlay = container.selectAll('rect')
@@ -101,6 +102,16 @@ export default function() {
     }
 
     function mousemove() {
+        var mouse = d3.mouse(this);
+        var container = d3.select(this);
+        var snapped = snap.apply(this, mouse);
+        var data = container.datum();
+        data[data.length - 1] = snapped;
+        container.call(crosshair);
+        event.trackingmove.apply(this, arguments);
+    }
+
+    function mousewheel() {
         var mouse = d3.mouse(this);
         var container = d3.select(this);
         var snapped = snap.apply(this, mouse);

--- a/src/tool/crosshair.js
+++ b/src/tool/crosshair.js
@@ -56,7 +56,7 @@ export default function() {
                 .style('pointer-events', 'all')
                 .on('mouseenter.crosshair', mouseenter)
                 .on('mousemove.crosshair', mousemove)
-                .on('wheel.crosshair', mousewheel)
+                .on('wheel.crosshair', mousemove)
                 .on('mouseleave.crosshair', mouseleave);
 
             var overlay = container.selectAll('rect')
@@ -102,16 +102,6 @@ export default function() {
     }
 
     function mousemove() {
-        var mouse = d3.mouse(this);
-        var container = d3.select(this);
-        var snapped = snap.apply(this, mouse);
-        var data = container.datum();
-        data[data.length - 1] = snapped;
-        container.call(crosshair);
-        event.trackingmove.apply(this, arguments);
-    }
-
-    function mousewheel() {
         var mouse = d3.mouse(this);
         var container = d3.select(this);
         var snapped = snap.apply(this, mouse);


### PR DESCRIPTION
While you are zooming into a chart with a crosshair pointer, such as [the Low Barrel example](http://d3fc.io/examples/low-barrel/), the crosshair pointer stays relative to the div, until a mousemove event occurs.  Ideally the crosshair pointer should follow what it was pointing at, using the "onwheel" event.

Fixes #836