### PR TITLE
Fix intermittent build errors caused by Windows XP

### DIFF
--- a/webdriver-tests/wdio.conf.js
+++ b/webdriver-tests/wdio.conf.js
@@ -6,6 +6,7 @@ exports.config = {
     ],
     capabilities: [
         {
+            platform: 'WIN8',
             browserName: 'chrome',
             'browserstack.local': true
         }


### PR DESCRIPTION
XP doesn't support the new TLS protocol used on https://d3fc.io