### PR TITLE
Gridlines now support ordinal scales

### DIFF
--- a/src/annotation/gridline.js
+++ b/src/annotation/gridline.js
@@ -7,8 +7,8 @@ export default function() {
 
     var xScale = d3.time.scale(),
         yScale = d3.scale.linear(),
-        xTicks = 10,
-        yTicks = 10;
+        xTickArguments = [10],
+        yTickArguments = [10];
 
     var xDecorate = noop,
         yDecorate = noop;
@@ -23,11 +23,16 @@ export default function() {
         .element('line')
         .attr('class', 'y gridline');
 
+    // applies the tick arguments for linear scales, or uses domain for ordinal scales
+    function getTicks(scale, tickArguments) {
+        return scale.ticks ? scale.ticks.apply(scale, tickArguments) : scale.domain();
+    }
+
     var gridlines = function(selection) {
 
         selection.each(function(data, index) {
 
-            var xData = xScale.ticks(xTicks);
+            var xData = getTicks(xScale, xTickArguments);
             var xLines = xLineDataJoin(this, xData);
 
             xLines.attr({
@@ -39,7 +44,7 @@ export default function() {
 
             xDecorate(xLines, xData, index);
 
-            var yData = yScale.ticks(yTicks);
+            var yData = getTicks(yScale, yTickArguments);
             var yLines = yLineDataJoin(this, yData);
 
             yLines.attr({
@@ -70,16 +75,16 @@ export default function() {
     };
     gridlines.xTicks = function(x) {
         if (!arguments.length) {
-            return xTicks;
+            return xTickArguments;
         }
-        xTicks = x;
+        xTickArguments = arguments;
         return gridlines;
     };
     gridlines.yTicks = function(x) {
         if (!arguments.length) {
-            return yTicks;
+            return yTickArguments;
         }
-        yTicks = x;
+        yTickArguments = arguments;
         return gridlines;
     };
     gridlines.yDecorate = function(x) {

--- a/tests/annotation/gridlinesSpec.js
+++ b/tests/annotation/gridlinesSpec.js
@@ -1,0 +1,54 @@
+describe('gridlines', function() {
+
+    var element;
+
+    beforeEach(function() {
+        element = document.createElement('svg');
+    });
+
+    function elementsWithClass(elements, classname) {
+        var elementsArray = Array.prototype.slice.call(elements, 0);
+        return elementsArray.filter(function(e) {
+            return e.classList.contains(classname);
+        });
+    }
+
+    it('should have an x and y line for each tick of a linear scale', function() {
+        var xScale = d3.scale.linear();
+        var yScale = d3.scale.linear();
+
+        var xTicks = 10, yTicks = 100;
+
+        var gridline = fc.annotation.gridline()
+            .xScale(xScale)
+            .yScale(yScale)
+            .xTicks(xTicks)
+            .yTicks(yTicks);
+
+        d3.select(element)
+            .datum([{}])
+            .call(gridline);
+
+        var xLines = elementsWithClass(element.children, 'x');
+        expect(xLines.length).toEqual(xScale.ticks(xTicks).length);
+
+        var yLines = elementsWithClass(element.children, 'y');
+        expect(yLines.length).toEqual(yScale.ticks(yTicks).length);
+    });
+
+    it('should utilise the domain for ordinal axes', function() {
+        var xScale = d3.scale.ordinal().domain(['1', '2', '3']);
+        var yScale = d3.scale.linear();
+
+        var gridline = fc.annotation.gridline()
+            .xScale(xScale)
+            .yScale(yScale);
+
+        d3.select(element)
+            .datum([{}])
+            .call(gridline);
+
+        var xLines = elementsWithClass(element.children, 'x');
+        expect(xLines.length).toEqual(3);
+    });
+});


### PR DESCRIPTION
Fixes #850 

Long-term it would probably make sense to add a base component that contains the tick logic, so that it can be shared between the axis and gridline component. This might also help resolve https://github.com/ScottLogic/d3fc/issues/653

However, for now this fix stops gridlines barfing when used with ordinal scales :-)

