### PR TITLE
gridlines use the range function that accommodates ordinal scales

### DIFF
--- a/site/src/examples/streaming/streaming.js
+++ b/site/src/examples/streaming/streaming.js
@@ -32,14 +32,22 @@ function renderChart() {
       )
      .xDomain(xExtent(data))
      .yDomain(yExtent(data))
-     .xTicks(5)
      .yNice()
-     .yTicks(5)
      .chartLabel('Streaming Candlestick')
      .margin({left: 30, right: 30, bottom: 20, top: 30});
 
+    // obtain ticks from the underlying scales
+    var xTicks = chart.xScaleTicks(10);
+    var yTicks = chart.yScaleTicks(10);
+
+    // render a reduced number of ticks on each axis
+    chart.xTickValues(xTicks.filter(function(d) { return d.getDate() % 2 === 0; }))
+        .yTickValues(yTicks.filter(function(d, i) { return i % 2 === 0; }));
+
     // Create the gridlines and series
-    var gridlines = fc.annotation.gridline();
+    var gridlines = fc.annotation.gridline()
+        .xTickValues(xTicks)
+        .yTickValues(yTicks);
     var candlestick = fc.series.candlestick();
     var bollingerBands = fc.indicator.renderer.bollingerBands();
 

--- a/src/annotation/gridline.js
+++ b/src/annotation/gridline.js
@@ -1,15 +1,14 @@
 import d3 from 'd3';
 import dataJoin from '../util/dataJoin';
+import ticks from '../scale/ticks';
 import {noop} from '../util/fn';
-import {rebind} from '../util/rebind';
+import {rebind, rebindAll} from '../util/rebind';
 import {range} from '../util/scale';
 
 export default function() {
 
-    var xScale = d3.time.scale(),
-        yScale = d3.scale.linear(),
-        xTickArguments = [10],
-        yTickArguments = [10];
+    var xTicks = ticks(),
+        yTicks = ticks();
 
     var xDecorate = noop,
         yDecorate = noop;
@@ -24,16 +23,14 @@ export default function() {
         .element('line')
         .attr('class', 'y gridline');
 
-    // applies the tick arguments for linear scales, or uses domain for ordinal scales
-    function getTicks(scale, tickArguments) {
-        return scale.ticks ? scale.ticks.apply(scale, tickArguments) : scale.domain();
-    }
-
     var gridlines = function(selection) {
 
         selection.each(function(data, index) {
 
-            var xData = getTicks(xScale, xTickArguments);
+            var xScale = xTicks.scale(),
+                yScale = yTicks.scale();
+
+            var xData = xTicks();
             var xLines = xLineDataJoin(this, xData);
 
             xLines.attr({
@@ -45,7 +42,7 @@ export default function() {
 
             xDecorate(xLines, xData, index);
 
-            var yData = getTicks(yScale, yTickArguments);
+            var yData = yTicks();
             var yLines = yLineDataJoin(this, yData);
 
             yLines.attr({
@@ -60,34 +57,7 @@ export default function() {
         });
     };
 
-    gridlines.xScale = function(x) {
-        if (!arguments.length) {
-            return xScale;
-        }
-        xScale = x;
-        return gridlines;
-    };
-    gridlines.yScale = function(x) {
-        if (!arguments.length) {
-            return yScale;
-        }
-        yScale = x;
-        return gridlines;
-    };
-    gridlines.xTicks = function(x) {
-        if (!arguments.length) {
-            return xTickArguments;
-        }
-        xTickArguments = arguments;
-        return gridlines;
-    };
-    gridlines.yTicks = function(x) {
-        if (!arguments.length) {
-            return yTickArguments;
-        }
-        yTickArguments = arguments;
-        return gridlines;
-    };
+
     gridlines.yDecorate = function(x) {
         if (!arguments.length) {
             return yDecorate;
@@ -105,6 +75,9 @@ export default function() {
 
     rebind(gridlines, xLineDataJoin, {'xKey': 'key'});
     rebind(gridlines, yLineDataJoin, {'yKey': 'key'});
+
+    rebindAll(gridlines, xTicks, 'x');
+    rebindAll(gridlines, yTicks, 'y');
 
     return gridlines;
 }

--- a/src/annotation/gridline.js
+++ b/src/annotation/gridline.js
@@ -2,6 +2,7 @@ import d3 from 'd3';
 import dataJoin from '../util/dataJoin';
 import {noop} from '../util/fn';
 import {rebind} from '../util/rebind';
+import {range} from '../util/scale';
 
 export default function() {
 
@@ -38,8 +39,8 @@ export default function() {
             xLines.attr({
                 'x1': xScale,
                 'x2': xScale,
-                'y1': yScale.range()[0],
-                'y2': yScale.range()[1]
+                'y1': range(yScale)[0],
+                'y2': range(yScale)[1]
             });
 
             xDecorate(xLines, xData, index);
@@ -48,8 +49,8 @@ export default function() {
             var yLines = yLineDataJoin(this, yData);
 
             yLines.attr({
-                'x1': xScale.range()[0],
-                'x2': xScale.range()[1],
+                'x1': range(xScale)[0],
+                'x2': range(xScale)[1],
                 'y1': yScale,
                 'y2': yScale
             });

--- a/src/chart/cartesian.js
+++ b/src/chart/cartesian.js
@@ -178,11 +178,15 @@ export default function(xScale, yScale) {
     };
 
     var scaleExclusions = [
+        'ticks',
         /range\w*/,   // the scale range is set via the component layout
         /tickFormat/  // use axis.tickFormat instead (only present on linear scales)
     ];
     rebindAll(cartesian, xScale, 'x', scaleExclusions);
     rebindAll(cartesian, yScale, 'y', scaleExclusions);
+
+    cartesian.xScaleTicks = xScale.ticks;
+    cartesian.yScaleTicks = yScale.ticks;
 
     var axisExclusions = [
         'baseline',         // the axis baseline is adapted so is not exposed directly

--- a/src/chart/cartesian.js
+++ b/src/chart/cartesian.js
@@ -6,7 +6,7 @@ import line from '../series/line';
 import dataJoin from '../util/dataJoin';
 import expandRect from '../util/expandRect';
 import {noop} from '../util/fn';
-import {rebindAll} from '../util/rebind';
+import {rebindAll, rebind} from '../util/rebind';
 import {isOrdinal, range, setRange} from '../util/scale';
 
 export default function(xScale, yScale) {
@@ -177,16 +177,29 @@ export default function(xScale, yScale) {
         });
     };
 
-    var scaleExclusions = [
-        'ticks',
-        /range\w*/,   // the scale range is set via the component layout
-        /tickFormat/  // use axis.tickFormat instead (only present on linear scales)
-    ];
-    rebindAll(cartesian, xScale, 'x', scaleExclusions);
-    rebindAll(cartesian, yScale, 'y', scaleExclusions);
+    function rebindScale(scale, prefix) {
+        var scaleExclusions = [
+            /range\w*/,   // the scale range is set via the component layout
+            /tickFormat/  // use axis.tickFormat instead (only present on linear scales)
+        ];
 
-    cartesian.xScaleTicks = xScale.ticks;
-    cartesian.yScaleTicks = yScale.ticks;
+        // The scale ticks method is a stateless method that returns (roughly) the number of ticks
+        // requested. This is subtley different from teh axis ticks methods that simple stores the given arguments
+        // for invocation of the scale method at some point in the future.
+        // Here we expose the underling scale ticks method in case the user want to generate their own ticks.
+        if (!isOrdinal(scale)) {
+            scaleExclusions.push('ticks');
+            var mappings = {};
+            mappings[prefix + 'ScaleTicks'] = 'ticks';
+            rebind(cartesian, scale, mappings);
+        }
+
+        rebindAll(cartesian, scale, prefix, scaleExclusions);
+    }
+
+    rebindScale(xScale, 'x');
+    rebindScale(yScale, 'y');
+
 
     var axisExclusions = [
         'baseline',         // the axis baseline is adapted so is not exposed directly

--- a/src/scale/ticks.js
+++ b/src/scale/ticks.js
@@ -1,0 +1,42 @@
+import d3 from 'd3';
+
+export default function() {
+
+    var scale = d3.scale.identity(),
+        tickArguments = [10],
+        tickValues = null;
+
+    function tryApply(fn, defaultVal) {
+        return scale[fn] ? scale[fn].apply(scale, tickArguments) : defaultVal;
+    }
+
+    var ticks = function() {
+        return tickValues == null ? tryApply('ticks', scale.domain()) : tickValues;
+    };
+
+    ticks.scale = function(x) {
+        if (!arguments.length) {
+            return scale;
+        }
+        scale = x;
+        return ticks;
+    };
+
+    ticks.ticks = function(x) {
+        if (!arguments.length) {
+            return tickArguments;
+        }
+        tickArguments = arguments;
+        return ticks;
+    };
+
+    ticks.tickValues = function(x) {
+        if (!arguments.length) {
+            return tickValues;
+        }
+        tickValues = x;
+        return ticks;
+    };
+
+    return ticks;
+}

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -5,7 +5,6 @@ import {identity, noop} from '../util/fn';
 import {range as scaleRange, isOrdinal} from '../util/scale';
 import {rebindAll} from '../util/rebind';
 
-
 // A drop-in replacement for the D3 axis, supporting the decorate pattern.
 export default function() {
 


### PR DESCRIPTION
Shouldn't have just relied on unit tests for #851 ;-)

 + Adds a ticks component (closes #852)
 + Streaming chart ticks and gridlines are aligned (fixes #653)