### PR TITLE
Support resizing for a number of examples

### DIFF
--- a/site/src/_includes/javascript-resize.hbs
+++ b/site/src/_includes/javascript-resize.hbs
@@ -1,0 +1,9 @@
+<script>
+(function() {
+    function render() {
+        {{{js}}}
+    }
+    render();
+    $(window).resize(fc.util.render(render));
+})();
+</script>

--- a/site/src/components/introduction/getting-started.md
+++ b/site/src/components/introduction/getting-started.md
@@ -57,9 +57,8 @@ Here is how the chart should look:
 {{{ dynamic-include 'codepen' html="getting-started-html" js="getting-started-js" }}}
 
 {{{getting-started-html}}}
-<script type="text/javascript">
-{{{getting-started-js}}}
-</script>
+
+{{{ dynamic-include 'javascript-resize' js="getting-started-js" }}}
 
 ## Next steps
 

--- a/site/src/examples/low-barrel/index.md
+++ b/site/src/examples/low-barrel/index.md
@@ -16,9 +16,7 @@ externals:
 
 {{{low-barrel-html}}}
 
-<script>
-{{{low-barrel-js}}}
-</script>
+{{{ dynamic-include 'javascript-resize' js="low-barrel-js" }}}
 
 This example shows how a more complex chart can be built using the d3fc components.
 

--- a/site/src/examples/scatter/index.md
+++ b/site/src/examples/scatter/index.md
@@ -16,9 +16,7 @@ externals:
 
 {{{scatter-html}}}
 
-<script>
-{{{scatter-js}}}
-</script>
+{{{ dynamic-include 'javascript-resize' js="scatter-js" }}}
 
 
 (based on [bl.ock #3887118](http://bl.ocks.org/mbostock/3887118#index.html) by Mike Bostock)

--- a/site/src/examples/simple/index.md
+++ b/site/src/examples/simple/index.md
@@ -16,9 +16,7 @@ externals:
 
 {{{simple-html}}}
 
-<script>
-{{{simple-js}}}
-</script>
+{{{ dynamic-include 'javascript-resize' js="simple-js" }}}
 
 This example demonstrates how to a simple cartesian chart with a line and an area series. The chart is constructed from the following components:
 

--- a/site/src/examples/stacked/index.md
+++ b/site/src/examples/stacked/index.md
@@ -16,9 +16,7 @@ externals:
 
 {{{stacked-html}}}
 
-<script>
-{{{stacked-js}}}
-</script>
+{{{ dynamic-include 'javascript-resize' js="stacked-js" }}}
 
 This example demonstrates how a stacked bar chart using energy production data from [eurostat](http://ec.europa.eu/eurostat/statistics-explained/index.php). The chart is constructed from the following components:
 


### PR DESCRIPTION
Improves #681 

The vast majority of the component examples now have a fixed width of 500px, so do not overlap the menu or have layout issues until the screen becomes quite narrow.

This changes ensures that all the 'full width' examples support resizing.