### PR TITLE
Use text-before-edge baseline for labels

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -211,7 +211,8 @@ module.exports = function(grunt) {
             site: {
                 files: [
                     '<%= meta.metaJsFiles %>',
-                    'site/src/**/*'
+                    'site/src/**/*',
+                    'dist/**/*'
                 ],
                 tasks: ['site:dev'],
                 options: {

--- a/site/src/style/examples.less
+++ b/site/src/style/examples.less
@@ -30,7 +30,3 @@
 .thumbnail {
   background-color: transparent;
 }
-
-.chart .title .label {
-  dominant-baseline: text-before-edge;
-}

--- a/src/fc.css
+++ b/src/fc.css
@@ -66,7 +66,7 @@ text {
 .x-axis.top .label,
 .y-axis.left .label,
 .title .label {
-  dominant-baseline: hanging;
+  dominant-baseline: text-before-edge;
 }
 
 .x-axis.bottom .label {
@@ -78,7 +78,7 @@ text {
 }
 
 .multiples-chart .label {
-  dominant-baseline: hanging;
+  dominant-baseline: text-before-edge;
 }
 
 .multiples-chart .background {


### PR DESCRIPTION
I picked the wrong baseline, it was originally 'hanging', should be 'text before edge'

![](http://www.w3.org/TR/2001/PR-xsl-20010828/AlignIntro-1.gif)

Also, tweaked the build so that the site build is kicked off by changes in d3fc distribution