### PR TITLE
Add missing d3-legend to the dependency list on site Getting Started page

### DIFF
--- a/site/src/components/introduction/getting-started.md
+++ b/site/src/components/introduction/getting-started.md
@@ -24,6 +24,7 @@ Once installed, you can reference the d3fc JavaScript, CSS and dependencies with
 ```html
 <script src="node_modules/d3fc/node_modules/d3/d3.js"></script>
 <script src="node_modules/d3fc/node_modules/css-layout/dist/css-layout.js"></script>
+<script src="node_modules/d3fc/node_modules/d3-svg-legend/d3-legend.js"></script>
 <script src="node_modules/d3fc/node_modules/svg-innerhtml/svg-innerhtml.js"></script>
 <script src="node_modules/d3fc/dist/d3fc.js"></script>
 


### PR DESCRIPTION
I'm assuming the should also be listed here, as it's included in the bundle.