### PR TITLE
Fixes the CI build, ensuring that the site works on browserstack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -335,7 +335,7 @@ module.exports = function(grunt) {
         ['connect:site', 'connect:visualTests', 'browserstacktunnel-wrapper', 'webdriver'] : []);
     grunt.registerTask('webdriverTests', ['eslint:webdriverTests', 'webdriverTests:browserstack']);
 
-    grunt.registerTask('ci', ['components', 'uglify:components', 'site',
+    grunt.registerTask('ci', ['components', 'uglify:components', 'site:dev',
         'uglify:site', 'visualTests', 'webdriverTests']);
 
     grunt.registerTask('default', ['watch:components']);


### PR DESCRIPTION
The CI tests run on localhost:8080, so must also use the site:dev target