### PR TITLE
Added a hyperlink helper

### DIFF
--- a/site/build/build.js
+++ b/site/build/build.js
@@ -38,6 +38,7 @@ require('./handlebars-helpers/dynamic-include').register(handlebars);
 require('./handlebars-helpers/escape').register(handlebars);
 require('./handlebars-helpers/codeblock').register(handlebars);
 require('./handlebars-helpers/json').register(handlebars);
+require('./handlebars-helpers/hyperlink').register(handlebars);
 
 function build(config) {
     // for dev builds don't syntax highlight

--- a/site/build/handlebars-helpers/hyperlink.js
+++ b/site/build/handlebars-helpers/hyperlink.js
@@ -5,11 +5,22 @@ function register(handlebars) {
         var matches = pages.filter(function(pageMetadata) {
             return pageMetadata.page.destination.endsWith('/' + link);
         });
+
+        if (!context.hash.title) {
+            throw new Error('A title was not provided for the hyperlink within page ' + context.data.root.page.path);
+        }
+
         if (matches.length === 1) {
             var title = context.hash.title;
             return '<a href=\"' + matches[0].page.destination + '\">' + title + '</a>';
         } else {
-            throw new Error('Unable to locate link ' + link + ' within page ' + context.data.root.page.path);
+            if (matches.length === 0) {
+                throw new Error('Unable to locate a page with the name ' + link + ' hyperlinked within page ' + context.data.root.page.path);
+            }
+            if (matches.length > 1) {
+                throw new Error('Multiple pages end with the name ' + link +
+                    ', expand the path in order to make the link un-ambiguous, hyperlinked within page ' + context.data.root.page.path);
+            }
         }
     });
 }

--- a/site/build/handlebars-helpers/hyperlink.js
+++ b/site/build/handlebars-helpers/hyperlink.js
@@ -1,0 +1,19 @@
+
+function register(handlebars) {
+    handlebars.registerHelper('hyperlink', function(link, context) {
+        var pages = context.data.root.pages;
+        var matches = pages.filter(function(pageMetadata) {
+            return pageMetadata.page.destination.endsWith('/' + link);
+        });
+        if (matches.length === 1) {
+            var title = context.hash.title;
+            return '<a href=\"' + matches[0].page.destination + '\">' + title + '</a>';
+        } else {
+            throw new Error('Unable to locate link ' + link + ' within page ' + context.data.root.page.path);
+        }
+    });
+}
+
+module.exports = {
+    register: register
+};

--- a/site/src/components/chart/cartesian.md
+++ b/site/src/components/chart/cartesian.md
@@ -26,4 +26,4 @@ This results in the following chart:
 {{{cartesian-example-js}}}
 </script>
 
-A number of the more [complex examples](/examples) use the cartesian chart as the basic 'boiler plate' for constructing a chart.
+A number of the more {{{ hyperlink 'examples/index.html' title='complex examples' }}} use the cartesian chart as the basic 'boiler plate' for constructing a chart.

--- a/site/src/components/chart/legend.md
+++ b/site/src/components/chart/legend.md
@@ -15,7 +15,7 @@ externals:
 
 Rather than write our own d3fc legend, we discovered that someone had already [created a pretty awesome one](http://d3-legend.susielu.com), so we decided to integrate that one instead! This project uses the `d3-svg-legend`, component which is included in the d3fc bundle.
 
-The d3-legend doesn't render a background, although this can easily be added via the [container component](/components/tool/container.html).
+The d3-legend doesn't render a background, although this can easily be added via the {{{ hyperlink 'container.html' title='container component' }}}.
 
 The d3-legend is constructed from a scale as shown below:
 

--- a/site/src/components/chart/small-multiples.md
+++ b/site/src/components/chart/small-multiples.md
@@ -29,7 +29,7 @@ This results in the following chart:
 {{{multiples-example-js}}}
 </script>
 
-From the above example it can be seen that the small multiples component has a similar API to the [cartesian chart](/components/chart/cartesian.html), re-binding the various x and y axis properties, and exposing `plotArea` and `margin` properties.
+From the above example it can be seen that the small multiples component has a similar API to the {{{ hyperlink 'cartesian.html' title='cartesian chart' }}}, re-binding the various x and y axis properties, and exposing `plotArea` and `margin` properties.
 
 The following example demonstrates a small multiples chart with a multi-row grid layout. In this example temperature data is loaded from a CSV file, with `d3.nest` used to manipulate the data into the required format. A multi-series component is used to render a couple of lines on each multiple plot.
 

--- a/site/src/components/chart/tooltip.md
+++ b/site/src/components/chart/tooltip.md
@@ -46,6 +46,6 @@ Which results in the following:
 
 Both the label and value for each row can be expressed as a constant or a function of the bound data.
 
-The tooltip uses [flexbox layout](/components/layout/flexbox.html) in order to construct the rows / columns. As a result, the size of the tooltip is determined by the size of its containing element, which is determined either by measuring the element dimensions, or from the `layout-width` and `layout-height` properties as described in the flexbox layout documentation.
+The tooltip uses {{{ hyperlink 'flexbox.html' title='flexbox layout' }}} in order to construct the rows / columns. As a result, the size of the tooltip is determined by the size of its containing element, which is determined either by measuring the element dimensions, or from the `layout-width` and `layout-height` properties as described in the flexbox layout documentation.
 
-The tooltip is most often used in conjunction with the crosshair component, consult the [crosshair documentation](/components/tool/crosshair.html) for more details.
+The tooltip is most often used in conjunction with the crosshair component, consult the {{{ hyperlink 'crosshair.html' title='crosshair documentation' }}} for more details.

--- a/site/src/components/data/spread.md
+++ b/site/src/components/data/spread.md
@@ -11,7 +11,7 @@ externals:
   spread-example-horizontal-html: spread-example-horizontal.html
 ---
 
-This spread component is primarily used for manipulating data obtained via `d3.csv` into a suitable form for rendering with the [stacked](/components/series/stacked.html), [grouped bar](/components/series/grouped-bar.html) or [small multiples](/components/chart/small-multiples.html) components.
+This spread component is primarily used for manipulating data obtained via `d3.csv` into a suitable form for rendering with the {{{ hyperlink 'stacked.html' title='stacked' }}}, {{{ hyperlink 'grouped-bar.html' title='grouped bar' }}} or {{{ hyperlink 'small-multiples.html' title='small multiples' }}} components.
 
 When data is loaded via `d3.csv`, it is converted into an array of objects, one per row, with properties names derived from the CSV 'column' headings. The `spread` component converts the data into an array of series, either one for each column (vertical spread), or one per row (horizontal spead). The column that identifies the name for each series is identified via the `xValueKey` property.
 

--- a/site/src/components/data/walk.md
+++ b/site/src/components/data/walk.md
@@ -10,7 +10,7 @@ externals:
 ---
 
 The random walk component creates a series of values based on the [Geometric Brownian Motion](http://stuartreid.co.za/interactive-stochastic-processes/) stochastic process.
-The [random financial](./financial.html) component uses it to create random open-high-low-close (OHLC) price data.
+The {{{ hyperlink 'financial.html' title='random financial' }}} component uses it to create random open-high-low-close (OHLC) price data.
 
 ```js
 {{{walk-example-js}}}

--- a/site/src/components/indicator/envelope.md
+++ b/site/src/components/indicator/envelope.md
@@ -28,8 +28,8 @@ The example below creates a line series which is bounded by an envelope:
 
 You can specify the value that is bounded by the envelope via the `value` property, also the distance between the upper and lower bounds can be controlled using the `factor` property.
 
-Envelopes are most often used with an [exponential moving average](./exponentialMovingAverage), where the a price that falls outside of the envelope constitutes either a buy or a sell signal. The following example creates a
-[candlestick series](../series/candlestick), an [exponential moving average](./exponentialMovingAverage)
+Envelopes are most often used with an {{{ hyperlink 'exponentialMovingAverage.html' title='exponential moving average' }}}, where the a price that falls outside of the envelope constitutes either a buy or a sell signal. The following example creates a
+{{{ hyperlink 'candlestick.html' title='candlestick series' }}}, an {{{ hyperlink 'exponentialMovingAverage.html' title='exponential moving average' }}}
 and an envelope indicator:
 
 ```js

--- a/site/src/components/indicator/forceIndex.md
+++ b/site/src/components/indicator/forceIndex.md
@@ -11,7 +11,7 @@ externals:
 
 A [Force Index](http://en.wikipedia.org/wiki/Force_index) is an indicator that illustrates how strong the actual buying
 or selling pressure is. It is calculated by subtracting today's closing price from yesterday's and
-multiplying the result by today's volume. The 13 day [Exponential Moving Average](/components/indicator/exponentialMovingAverage)
+multiplying the result by today's volume. The 13 day {{{ hyperlink 'exponentialMovingAverage.html' title='Exponential Moving Average' }}}
 of the Force Index is often used. The Force Index is typically plotted on a chart centered around the 0 line.
 Attention is given to the relative size and trends in the Index.
 

--- a/site/src/components/introduction/building-a-chart.md
+++ b/site/src/components/introduction/building-a-chart.md
@@ -47,13 +47,13 @@ D3 offers a fresh perspective, offering a different way to create charts and vis
 
 There are a number of charting libraries built with D3, however these invariably hide the underlying power of D3 behind the same-old complex and confusing APIs.
 
-With d3fc our aim is to enhance D3 by providing a suite of powerful [charting components](http://bost.ocks.org/mike/chart/) that make it easy for you to assemble exactly the chart you want. These components 'speak the language' of D3, supporting [selections](http://bost.ocks.org/mike/selection/) and [data joins](http://bost.ocks.org/mike/join/). Furthermore, using the [decorate pattern](https://d3fc.io/components/introduction/decorate-pattern.html), you can enhance and manipulate the way in which they are rendered.
+With d3fc our aim is to enhance D3 by providing a suite of powerful [charting components](http://bost.ocks.org/mike/chart/) that make it easy for you to assemble exactly the chart you want. These components 'speak the language' of D3, supporting [selections](http://bost.ocks.org/mike/selection/) and [data joins](http://bost.ocks.org/mike/join/). Furthermore, using the {{{ hyperlink 'decorate-pattern.html' title='decorate pattern' }}}, you can enhance and manipulate the way in which they are rendered.
 
 With d3fc components you can quickly assemble bespoke charts, without hiding the power of D3.
 
 ## Creating the data
 
-Typically chart data will be supplied by some external source, in JSON or CSV format. For the purposes of this example we'll just generate some random data. d3fc has a number of `data` utilities, including components that help construct realistic random data. For this example we'll use the [random walk component](/components/data/walk.html) to generate 12 datapoints, mapping them to create datapoints with `sales` and `month` properties:
+Typically chart data will be supplied by some external source, in JSON or CSV format. For the purposes of this example we'll just generate some random data. d3fc has a number of `data` utilities, including components that help construct realistic random data. For this example we'll use the {{{ hyperlink 'walk.html' title='random walk component' }}} to generate 12 datapoints, mapping them to create datapoints with `sales` and `month` properties:
 
 ```js
 {{{creating-some-data-js}}}
@@ -69,7 +69,7 @@ Here's the resulting data:
 
 The sales data is rendered as a bar chart. With D3 this typically involves rendering paths or rectangles and doing a bit of maths to locate each bar correctly, as illustrated in [Mike Bostock's excellent tutorial](http://bost.ocks.org/mike/bar/).
 
-d3fc has a [bar series component](/components/series/bar.html) (among others) that makes this task much easier. To render the data, we create a bar series component and supply it with suitable D3 scales, configure the `xValue` and `yValue` accessors (which the component uses to extract the x and y values from the datapoints).
+d3fc has a {{{ hyperlink 'bar.html' title='bar series component' }}} (among others) that makes this task much easier. To render the data, we create a bar series component and supply it with suitable D3 scales, configure the `xValue` and `yValue` accessors (which the component uses to extract the x and y values from the datapoints).
 
 The bar series is a regular D3 component, and is rendered via the `call` method on a D3 selection:
 
@@ -118,7 +118,7 @@ data.map(function(d) { return d.month; })
 
 The current y-domain is a bit of a guess, being hard-coded to a range `[0, 10]`. Ideally the domain should be computed based on the data. In this case the domain should accommodate the greatest sales value, plus some padding, and also extent to zero.
 
-There's another d3fc component that can help here, the [extent](/components/util/extent.html) utility. The following code ensures that zero is included, and adds a small amount of padding, as a percentage of the overall extent, to the 'top' end of the range:
+There's another d3fc component that can help here, the {{{ hyperlink 'extent.html' title='extent' }}} utility. The following code ensures that zero is included, and adds a small amount of padding, as a percentage of the overall extent, to the 'top' end of the range:
 
 ```js
 {{{ codeblock cartesian-chart-extent-js }}}
@@ -150,7 +150,7 @@ d3fc extends the D3 rebind concept by making it easier to rebind all of the prop
 
 ## Annotations
 
-The sales targets, which are illustrated as horizontal lines on the chart, can be rendered using the [line annotation component](/components/annotation/line.html).
+The sales targets, which are illustrated as horizontal lines on the chart, can be rendered using the {{{ hyperlink 'series/line.html' title='line annotation component' }}}.
 
 The chart now has two sources of data, an array of monthly sales figures, and a second array which supplies annotation values. These need to be combined into a single object which is supplied to the chart via the D3 `datum` method as before.
 
@@ -160,7 +160,7 @@ The chart now has two sources of data, an array of monthly sales figures, and a 
 
 As you can see in the above code, the `data` now has two properties, `targets` and `sales`, one for the annotations, the other for the series. As a results of this, the extent and domain calculations are updated to reference `data.sales`.
 
-But how to add the annotations to the chart? Annotations, just like series, are associated with both an x and a y scale, so can be supplied to the chart via the `plotArea`. But the bar series is currently set as the plot area. The solution to this problem is the [multi series component](/components/series/multi.html). This component acts a container for multiple series instances, setting their scales and also (optionally) mapping the data so that each series can be bound to a subset of the data. If a mapping function is not provided, each series will 'inherit' the data bound to the multi series component.
+But how to add the annotations to the chart? Annotations, just like series, are associated with both an x and a y scale, so can be supplied to the chart via the `plotArea`. But the bar series is currently set as the plot area. The solution to this problem is the {{{ hyperlink 'multi.html' title='multi series component' }}}. This component acts a container for multiple series instances, setting their scales and also (optionally) mapping the data so that each series can be bound to a subset of the data. If a mapping function is not provided, each series will 'inherit' the data bound to the multi series component.
 
 Here's the result:
 
@@ -172,9 +172,9 @@ Here's the result:
 
 The chart is starting to look pretty good! The only remaining tasks are to add text to the annotations and highlight the bars which have exceeded the lower target line.
 
-This is an interesting problem, the elements that need to be styled or modified have been created by the various components you have been making use of. How do you modify the way that components render themselves? This is where [decorate pattern](/components/introduction/decorate-pattern.html) comes in.
+This is an interesting problem, the elements that need to be styled or modified have been created by the various components you have been making use of. How do you modify the way that components render themselves? This is where {{{ hyperlink 'decorate-pattern.html' title='decorate pattern' }}} comes in.
 
-With the decorate pattern you gain access to the data join that is used to render a component, this allows you to add logic to the enter, update and exit selections, adding elements or mutating the elements that the component itself constructs. You can see numerous examples of this pattern in the [decorate pattern](/components/introduction/decorate-pattern.html) documentation.
+With the decorate pattern you gain access to the data join that is used to render a component, this allows you to add logic to the enter, update and exit selections, adding elements or mutating the elements that the component itself constructs. You can see numerous examples of this pattern in the {{{ hyperlink 'decorate-pattern.html' title='decorate pattern' }}} documentation.
 
 In this case, decorate is used to locate the 'left handle' of the line annotation, to add the text label, and to change the fill property of the path elements used to render the bar series.
 
@@ -193,7 +193,7 @@ And here's the result:
 
 The chart is rendering using SVG graphics. If the size of the SVG container changes, the various layout calculations within the cartesian chart component need to be re-evaluated. Because all the d3fc components respect D3 data joins, you can re-render them in their entirety whenever the data changes, or, in the case of the cartesian component, the containing element changes size.
 
-This pattern makes it incredibly simple to handle changes in data, see the [streaming example](/examples/streaming/index.html), or layout changes.
+This pattern makes it incredibly simple to handle changes in data, see the {{{ hyperlink 'streaming/index.html' title='streaming example' }}}, or layout changes.
 
 Here's how to use this technique to handle re-sizing the chart. Simply wrap the D3 select and call invocation in a function, in this case called `render`, and invoke it each time the window size changes:
 

--- a/site/src/components/introduction/getting-started.md
+++ b/site/src/components/introduction/getting-started.md
@@ -63,4 +63,4 @@ Here is how the chart should look:
 {{{getting-started-js}}}
 </script>
 
-The next step is to follow the more in-depth tutorial on [building a chart](/components/introduction/building-a-chart.html).
+The next step is to follow the more in-depth tutorial on {{{ hyperlink 'building-a-chart.html' title='building a chart' }}}.

--- a/site/src/components/layout/rectangles.md
+++ b/site/src/components/layout/rectangles.md
@@ -23,7 +23,7 @@ svg {
 
 The rectangles layout component provides a mechanism for arranging child components based on their rectangular bounding boxes. It is typically used to render tooltips or labels on a chart. A layout strategy can be passed to the component in order to arrange the child rectangles avoiding collisions.
 
-The component has `xScale` and `yScale` properties which it uses to determine the width and height of the overall container. Typically this component would be used with a [multi series](/components/series/multi.html) within a [cartesian chart](/components/chart/cartesian.html) hence these properties would not need to be set directly.
+The component has `xScale` and `yScale` properties which it uses to determine the width and height of the overall container. Typically this component would be used with a {{{ hyperlink 'multi.html' title='multi series' }}} within a {{{ hyperlink 'cartesian.html' title='cartesian chart' }}} hence these properties would not need to be set directly.
 
 The `size` and `position` of each child can be specified via constants or as accessor functions of the underlying bound data.
 
@@ -44,7 +44,7 @@ Which is rendered as follows:
 {{{rectangles-greedy-js}}}
 </script>
 
-NOTE: The rectangles layout component sets the `layout-width` and `layout-height` attributes of the generated child component containers, this allows the child component to use [flexbox layout](/components/layout/flexbox.html).
+NOTE: The rectangles layout component sets the `layout-width` and `layout-height` attributes of the generated child component containers, this allows the child component to use {{{ hyperlink 'flexbox.html' title='flexbox layout' }}}.
 
 The rectangles layout component can be used with different layout strategies which can, for example, ensure that rectangles do not overlap each other or all outside of the container.
 

--- a/site/src/components/series/bar.md
+++ b/site/src/components/series/bar.md
@@ -29,7 +29,7 @@ Which gives the following:
 {{{bar-example-js}}}
 </script>
 
-This series has the same `xValue`, `yValue` and `decorate` properties as the [point series](./point). You can also specify the width of the bars via the `barWidth` property.
+This series has the same `xValue`, `yValue` and `decorate` properties as the {{{ hyperlink 'point.html' title='point series' }}}. You can also specify the width of the bars via the `barWidth` property.
 
 The bar series supports horizonal display, using the `orient` property.
 

--- a/site/src/components/series/line.md
+++ b/site/src/components/series/line.md
@@ -26,7 +26,7 @@ Which gives the following:
 {{{line-example-js}}}
 </script>
 
-This series has the same properties for specifying the x and y value accessors, and decorate as the [point series](#point).
+This series has the same properties for specifying the x and y value accessors, and decorate as the {{{ hyperlink 'point.html' title='point series' }}}.
 
 The line series component also exposes the `interpolate` and `tension` properties from the D3 line shape that it uses for rendering. For more information about the interpolation modes refer to the official [D3 Line Documentation](https://github.com/mbostock/d3/wiki/SVG-Shapes#line).
 

--- a/site/src/components/series/ohlc.md
+++ b/site/src/components/series/ohlc.md
@@ -25,4 +25,4 @@ Which gives the following:
 {{{ohlc-example-js}}}
 </script>
 
-The OHLC series shares the same configuration options as the [candlestick series](#candlestick).
+The OHLC series shares the same configuration options as the {{{ hyperlink 'candlestick.html' title='candlestick series' }}}.

--- a/site/src/components/series/waterfall.md
+++ b/site/src/components/series/waterfall.md
@@ -32,6 +32,6 @@ Which gives the following:
 
 The data that identifies the x-value is identified via the `xValueKey` property.
 
-This series has the same `yValue` and `decorate` properties as the [point series](./point). You can also specify the width of the bars via the `barWidth` property.
+This series has the same `yValue` and `decorate` properties as the {{{ hyperlink 'point.html' title='point series' }}}. You can also specify the width of the bars via the `barWidth` property.
 
-The waterfall series supports horizontal display, using the `orient` property, similar to [bar](./bar).
+The waterfall series supports horizontal display, using the `orient` property, similar to {{{ hyperlink 'bar.html' title='bar' }}}.

--- a/site/src/components/tool/crosshair.md
+++ b/site/src/components/tool/crosshair.md
@@ -32,9 +32,9 @@ You can control the snapping behaviour of the crosshair by supplying a snapping 
 
 You can configure X and Y labels via the `xLabel` and `yLabel` properties. The crosshair emits `trackingstart`, `trackingmove` and `trackingend` events which can be used to add further interactively.
 
-The crosshair is often used in conjunction with the [tooltip component](/components/chart/tooltip.html), which renders the data that the crosshair generates (and pushes into the data-joined array). In order to update the tooltip component, the entire chart should be re-rendered by handling the crosshair tracking events.
+The crosshair is often used in conjunction with the {{{ hyperlink 'tooltip.html' title='tooltip component' }}}, which renders the data that the crosshair generates (and pushes into the data-joined array). In order to update the tooltip component, the entire chart should be re-rendered by handling the crosshair tracking events.
 
-While the tooltip can be rendered into any suitable container, it often makes sense to render it within the same region as the series. In order to achieve this, the tooltip can be positioned by the [rectangles layout component](/components/layout/rectangles.html).
+While the tooltip can be rendered into any suitable container, it often makes sense to render it within the same region as the series. In order to achieve this, the tooltip can be positioned by the {{{ hyperlink 'rectangles.html' title='rectangles layout component' }}}.
 
 The following shows how these various components can be integrated together:
 

--- a/site/src/examples/bubble/index.md
+++ b/site/src/examples/bubble/index.md
@@ -23,9 +23,9 @@ externals:
 This example demonstrates how to render a bubble chart with data that shows the relationship between life expectancy and wealth, obtained via  [Gapminder](http://www.gapminder.org/world/#$majorMode=chart$is;shi=t;ly=2003;lb=f;il=t;fs=11;al=30;stl=t;st=t;nsl=t;se=t$wst;tts=C$ts;sp=5.59290322580644;ti=2013$zpv;v=0$inc_x;mmid=XCOORDS;iid=phAwcNAVuyj1jiMAkmq1iMg;by=ind$inc_y;mmid=YCOORDS;iid=phAwcNAVuyj2tPLxKvvnNPA;by=ind$inc_s;uniValue=8.21;iid=phAwcNAVuyj0XOoBL_n5tAQ;by=ind$inc_c;uniValue=255;gid=CATID0;by=grp$map_x;scale=log;dataMin=194;dataMax=96846$map_y;scale=lin;dataMin=23;dataMax=86$map_s;sma=49;smi=2.65$cd;bd=0$inds=;modified=60). The chart is constructed from the following components:
 
  + The `d3.json` component is used to load the data from a JSON file.
- + A [cartesian chart](/components/chart/cartesian.html), with a logarithmic x scale and linear y scale, is used to render the plot area, axes and labels.
- + A [point series](/components/series/point.html) is used to render the data, with the `size` of each point defined via another linear scale.
- + The [decorate pattern](/components/introduction/decorate-pattern.html) is used to add a legend (courtesy of the [d3-legend](http://d3-legend.susielu.com) project). In this case, the legend is inserted into the SVG via the enter selection, with [svg flexbox](/components/layout/layout.html) used for positioning.
+ + A {{{ hyperlink 'cartesian.html' title='cartesian chart' }}}, with a logarithmic x scale and linear y scale, is used to render the plot area, axes and labels.
+ + A {{{ hyperlink 'point.html' title='point series' }}} is used to render the data, with the `size` of each point defined via another linear scale.
+ + The {{{ hyperlink 'decorate-pattern.html' title='decorate pattern' }}} is used to add a legend (courtesy of the [d3-legend](http://d3-legend.susielu.com) project). In this case, the legend is inserted into the SVG via the enter selection, with {{{ hyperlink 'flexbox.html' title='svg flexbox' }}} used for positioning.
 
 
 ```js

--- a/site/src/examples/index.md
+++ b/site/src/examples/index.md
@@ -3,7 +3,7 @@ layout: example
 title: Examples
 ---
 
-d3fc provides the building block that you can use to construct complex and highly customised charts. This page shows a number of examples ranging from the simple (for example a [scatter](/examples/scatter), or [bubble](/examples/bubble) chart) to the highly complex, for example a [3D chart with SVG filters](/examples/basecoin)!
+d3fc provides the building block that you can use to construct complex and highly customised charts. This page shows a number of examples ranging from the simple (for example a {{{ hyperlink 'scatter/index.html' title='scatter' }}}, or {{{ hyperlink 'bubble/index.html' title='bubble' }}} chart) to the highly complex, for example a {{{ hyperlink 'basecoin/index.html' title='3D chart with SVG filters' }}}!
 
 <div class="row">
   {{#each pages}}

--- a/site/src/examples/low-barrel/index.md
+++ b/site/src/examples/low-barrel/index.md
@@ -20,7 +20,7 @@ externals:
 
 This example shows how a more complex chart can be built using the d3fc components.
 
-The three charts that make up this example are each [cartesian charts](../../components/chart/cartesian.html). The top-most chart uses the [gridlines](../../components/annotation/gridlines.html), [crosshairs](../../components/tool/crosshairs.html) and [candlestick](../../components/series/candlestick.html) components, rendered via the [multi-series](../../components/series/multi.html) component. The volume and navigator charts uses a similar mix of components.
+The three charts that make up this example are each {{{ hyperlink 'cartesian.html' title='cartesian charts' }}}. The top-most chart uses the {{{ hyperlink 'gridlines.html' title='gridlines' }}}, {{{ hyperlink 'crosshair.html' title='crosshairs' }}} and {{{ hyperlink 'candlestick.html' title='candlestick' }}} components, rendered via the {{{ hyperlink 'multi.html' title='multi-series' }}} component. The volume and navigator charts uses a similar mix of components.
 
 These charts all share the same underlying data, however, this is enhanced with the data that represents the current interactive state.
 

--- a/site/src/examples/scatter/index.md
+++ b/site/src/examples/scatter/index.md
@@ -24,9 +24,9 @@ externals:
 This example demonstrates how to render a simple scatter plot with data from the [Iris flower dataset](https://en.wikipedia.org/wiki/Iris_flower_data_set). The chart is constructed from the following components:
 
  + The `d3.tsv` component is used to load a tab-separated data file.
- + A [cartesian chart](/components/chart/cartesian.html), with linear scales for x and y, is used to render the plot area, axes and labels.
- + A [point series](/components/series/point.html) is used to render the data, with the [decorate pattern](/components/introduction/decorate-pattern.html) used to colour each point.
- + The [decorate pattern](/components/introduction/decorate-pattern.html) is also used to add a legend (courtesy of the [d3-legend](http://d3-legend.susielu.com) project). In this case, the legend is inserted into the SVG via the enter selection, with [svg flexbox](/components/layout/layout.html) used for positioning.
+ + A {{{ hyperlink 'cartesian.html' title='cartesian chart' }}}, with linear scales for x and y, is used to render the plot area, axes and labels.
+ + A {{{ hyperlink 'point.html' title='point series' }}} is used to render the data, with the {{{ hyperlink 'decorate-pattern.html' title='decorate pattern' }}} used to colour each point.
+ + The {{{ hyperlink 'decorate-pattern.html' title='decorate pattern' }}} is also used to add a legend (courtesy of the [d3-legend](http://d3-legend.susielu.com) project). In this case, the legend is inserted into the SVG via the enter selection, with {{{ hyperlink 'flexbox.html' title='svg flexbox' }}} used for positioning.
 
 
 ```js

--- a/site/src/examples/simple/index.md
+++ b/site/src/examples/simple/index.md
@@ -20,10 +20,10 @@ externals:
 
 This example demonstrates how to a simple cartesian chart with a line and an area series. The chart is constructed from the following components:
 
- + A [cartesian chart](/components/chart/cartesian.html), with linear scales for x and y, is used to render the plot area, axes and labels. The `xBaseline` property is used to render the legend on the `y = 0` line.
- + The data is rendered via a [line series](/components/series/line.html) and an [area series](/components/series/area.html), these are combined into a single series using the [multi series](/components/series/multi.html) component.
- + A [gridlines component](/components/annotation/gridlines.html) is also added to the multi series.
- + The [extent](/components/util/extent.html) utility function is used to calculate the domain for the x and y scale, with padding applied to the y scale.
+ + A {{{ hyperlink 'cartesian.html' title='cartesian chart' }}}, with linear scales for x and y, is used to render the plot area, axes and labels. The `xBaseline` property is used to render the legend on the `y = 0` line.
+ + The data is rendered via a {{{ hyperlink 'series/line.html' title='line series' }}} and an {{{ hyperlink 'area.html' title='area series' }}}, these are combined into a single series using the {{{ hyperlink 'multi.html' title='multi series' }}} component.
+ + A {{{ hyperlink 'gridlines.html' title='gridlines component' }}} is also added to the multi series.
+ + The {{{ hyperlink 'extent.html' title='extent' }}} utility function is used to calculate the domain for the x and y scale, with padding applied to the y scale.
 
 ```js
 {{{simple-js}}}

--- a/site/src/examples/stacked/index.md
+++ b/site/src/examples/stacked/index.md
@@ -20,10 +20,10 @@ externals:
 
 This example demonstrates how a stacked bar chart using energy production data from [eurostat](http://ec.europa.eu/eurostat/statistics-explained/index.php). The chart is constructed from the following components:
 
- + A [cartesian chart](/components/chart/cartesian.html), with an ordinal y axis and a linear x axis.
- + The data is prepared using the [spread](/components/data/spread.html) component, which creates a two dimensional array of data, followed by a D3 stack layout, which stacks the 'y' values.
- + The data is rendered via a horizontally oriented [stacked bar series](/components/series/stacked.html).
- + The [decorate pattern](/components/introduction/decorate-pattern.html) is also used to add a legend (courtesy of the [d3-legend](http://d3-legend.susielu.com) project). In this case, the legend is inserted into the SVG via the enter selection, with [svg flexbox](/components/layout/layout.html) used for positioning.
+ + A {{{ hyperlink 'cartesian.html' title='cartesian chart' }}}, with an ordinal y axis and a linear x axis.
+ + The data is prepared using the {{{ hyperlink 'spread.html' title='spread' }}} component, which creates a two dimensional array of data, followed by a D3 stack layout, which stacks the 'y' values.
+ + The data is rendered via a horizontally oriented {{{ hyperlink 'stacked.html' title='stacked bar series' }}}.
+ + The {{{ hyperlink 'decorate-pattern.html' title='decorate pattern' }}} is also used to add a legend (courtesy of the [d3-legend](http://d3-legend.susielu.com) project). In this case, the legend is inserted into the SVG via the enter selection, with {{{ hyperlink 'flexbox.html' title='svg flexbox' }}} used for positioning.
 
 ```js
 {{{stacked-js}}}

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -98,20 +98,20 @@ externals:
     <div class="row">
       <div class="col-sm-3 ">
         <h3>Install</h3>
-        <p>A complete set of instructions for obtaining d3fc and its dependencies via npm or cdnjs are available in the <a href="components/introduction/getting-started.html">Getting Started Guide</a>.</p>
+        <p>A complete set of instructions for obtaining d3fc and its dependencies via npm or cdnjs are available in the {{{ hyperlink 'getting-started.html' title='Getting Started Guide' }}}.</p>
       </div>
       <div class="col-sm-3 ">
         <h3>Learn</h3>
-        <p>Follow the tutorial on <a href="components/introduction/building-a-chart.html">Building a Chart</a> to learn the concepts and principles behind d3fc. You can mix and match d3fc components with any D3 code you may require to produce your chart.</p>
+        <p>Follow the tutorial on {{{ hyperlink 'building-a-chart.html' title='Building a Chart' }}} to learn the concepts and principles behind d3fc. You can mix and match d3fc components with any D3 code you may require to produce your chart.</p>
       </div>
       <div class="col-sm-3 ">
         <h3>Customise</h3>
-        <p>The components are customised via CSS, allowing you to change colors, stroke, fill and layout. However for deeper customisation all the components support the <a href="components/introduction/decorate-pattern.html">decorate pattern</a>.</p>
+        <p>The components are customised via CSS, allowing you to change colors, stroke, fill and layout. However for deeper customisation all the components support the {{{ hyperlink 'decorate-pattern.html' title='decorate pattern' }}}.</p>
       </div>
       <div class="col-sm-3 ">
         <h3>Contribute</h3>
         <p>Spotted a bug? Have an idea for a feature? Please <a href="{{package.repository.url}}">pop over to GitHub and contribute</a>. If you want to contribute a new component, please read
-        over <a href="components/introduction/component-design.html">this page which describes the design goals</a>.</p>
+        over {{{ hyperlink 'component-design.html' title='this page which describes the design goals' }}}.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This helper is used to ensure that internal links are correct, making it easier to re-structure the site within issues.

The basic concept is to replace manual links:

    [cartesian chart](/components/chart/cartesian.html)

With the following:

    {{{ hyperlink 'container.html' title='container component' }}}

This constructs the correct hyperlink by finding the page that has a path ending with `container.html`.

I found a few broken links when implementing this ;-)

I'll stop messing around with the site build soon ...