### PR TITLE
Small style tweaks to visual test index page width and heading font weights

### DIFF
--- a/visual-tests/index.css
+++ b/visual-tests/index.css
@@ -4,19 +4,26 @@ body {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
+.container {
+  max-width: 970px; /* iframe max-width (940px) + horizontal padding (15px each side) */
+}
+
 h1,
 h2,
+.h1,
+.h2 {
+  font-weight: 700;
+}
+
 h3,
 h4,
 h5,
 h6,
-.h1,
-.h2,
 .h3,
 .h4,
 .h5,
 .h6 {
-  font-weight: 700;
+  font-weight: 500;
 }
 
 iframe {


### PR DESCRIPTION
I've been looking at the visual tests quite a bit recently - this is just a couple of tweaks to make the index page look a bit nicer (IMO). Feel free to reject this though :)

### Before

![before](https://cloud.githubusercontent.com/assets/2017615/13125910/e1636aa6-d5bf-11e5-98a1-14e22589265a.png)

### After

![after](https://cloud.githubusercontent.com/assets/2017615/13125930/fb83d222-d5bf-11e5-9dc1-43052faadd2d.png)
