### PR TITLE
Remove duplicate ESLint rule (eol-last)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -104,7 +104,6 @@
         "comma-spacing": 2,
         "comma-style": 2,
         "consistent-this": 2,
-        "eol-last": 0,
         "func-names": 0,
         "func-style": 0,
         "indent": 2,


### PR DESCRIPTION
Already on [line 157](https://github.com/ScottLogic/d3fc/blob/a95d8b96e07b581ee983496280701188abcf5390/.eslintrc#L157) (I think we want the stricter setting).

---

_I've got some more interesting work in progress - I'll share that soon, to offset all of these small (fairly boring) PRs!_