### PR TITLE
Crosshairs now filter the data before applying the snapping function

### DIFF
--- a/src/util/minimum.js
+++ b/src/util/minimum.js
@@ -1,3 +1,4 @@
+// returns the item from the given array that returns the least value from the accessor function
 export default function minimum(data, accessor) {
     return data.map(function(dataPoint) {
         return [accessor(dataPoint), dataPoint];

--- a/src/util/snap.js
+++ b/src/util/snap.js
@@ -1,3 +1,6 @@
+import {defined} from './fn';
+import minimum from './minimum';
+
 export function noSnap(xScale, yScale) {
     return function(xPixel, yPixel) {
         return {
@@ -16,13 +19,13 @@ export function pointSnap(xScale, yScale, xValue, yValue, data, objectiveFunctio
     };
 
     return function(xPixel, yPixel) {
-        var nearest = data.map(function(d) {
-            var diff = objectiveFunction(xPixel, yPixel, xScale(xValue(d)), yScale(yValue(d)));
-            return [diff, d];
-        })
-        .reduce(function(accumulator, value) {
-            return accumulator[0] > value[0] ? value : accumulator;
-        }, [Number.MAX_VALUE, null])[1];
+        var filtered = data.filter(function(d, i) {
+            return defined(xValue, yValue)(d, i);
+        });
+
+        var nearest = minimum(filtered, function(d) {
+            return objectiveFunction(xPixel, yPixel, xScale(xValue(d)), yScale(yValue(d)));
+        });
 
         return {
             datum: nearest,

--- a/visual-tests/tool/crosshair.js
+++ b/visual-tests/tool/crosshair.js
@@ -4,6 +4,9 @@
     var data = fc.data.random.financial().startDate(new Date(2014, 1, 1))(50);
     data.crosshair = [];
 
+    // throw in a null value to test crosshair data filtering
+    data[10].close = null;
+
     var width = 600, height = 250;
 
     var container = d3.select('#crosshair')


### PR DESCRIPTION
closes #897 #898 

@rjmcneill @jleft I think this is a better fix for #897 - the underlying issue is that the crosshair snap functions were not filtering undefined points. If a series has defined x values but undefined y values, and is snapping in the x direction, this results in the renderer being exposed to undefined values, causing the problems you observed.