### PR TITLE
Fixes vertical baseline issues with Safari

### DIFF
--- a/src/chart/cartesian.js
+++ b/src/chart/cartesian.js
@@ -79,7 +79,7 @@ export default function(xScale, yScale) {
                 </g> \
                 <g class="x-axis label-container"> \
                     <g layout-style="height: 0; width: 0"> \
-                        <text class="label"/> \
+                        <text class="label" dy="-0.5em"/> \
                     </g> \
                 </g> \
                 <g class="y-axis label-container"> \

--- a/src/fc.css
+++ b/src/fc.css
@@ -70,7 +70,7 @@ text {
 }
 
 .x-axis.bottom .label {
-  dominant-baseline: ideographic;
+  dominant-baseline: middle;
 }
 
 .cartesian-chart, .multiples-chart {


### PR DESCRIPTION
Fixes #877 

Safari and Chrome disagree over ideographic and text-after-edge baselines.

This fix uses a 25% baseline shift, which positions the text above the baseline:

```
<svg width="1200">
  <line x1='0' y1='20' x2='1200' y2='20'
        stroke="#999" 
        stroke-width="0.5"/>
  <text y="20" baseline-shift="25%">This is a quick test</text>
</svg>
```

<img width="138" alt="screen shot 2016-02-23 at 09 51 58" src="https://cloud.githubusercontent.com/assets/1098110/13247775/269f0e66-da13-11e5-9529-cc211b8f5326.png">

While this is not perfect (it assumes that the font extends beneath the baseline by no more than 25%), it is probably fine for most languages based around the roman alphabet.
