### PR TITLE
Remove unbundled from quick start

### DIFF
--- a/site/src/components/introduction/getting-started.md
+++ b/site/src/components/introduction/getting-started.md
@@ -23,16 +23,12 @@ npm install d3fc
 Once installed, you can reference the d3fc JavaScript, CSS and dependencies within an HTML page as follows:
 
 ```html
-<script src="node_modules/d3fc/node_modules/d3/d3.js"></script>
-<script src="node_modules/d3fc/node_modules/css-layout/dist/css-layout.js"></script>
-<script src="node_modules/d3fc/node_modules/d3-svg-legend/d3-legend.js"></script>
-<script src="node_modules/d3fc/node_modules/svg-innerhtml/svg-innerhtml.js"></script>
-<script src="node_modules/d3fc/dist/d3fc.js"></script>
+<script src="node_modules/d3fc/dist/d3fc.bundle.js"></script>
 
 <link href="node_modules/d3fc/dist/d3fc.css" rel="stylesheet"/>
 ```
 
-### Bundles
+### CDN hosted version
 
 Alternatively you can link to the latest version of d3fc and its dependencies directly:
 


### PR DESCRIPTION
As we break up d3fc the unbundled section is going to grow beyond a useful size. It is also implicitly referencing the old npm folder layout.