### PR TITLE
removeOverlaps now adapts other strategies

### DIFF
--- a/src/layout/strategy/removeOverlaps.js
+++ b/src/layout/strategy/removeOverlaps.js
@@ -1,10 +1,16 @@
 import minimum from '../../util/minimum';
+import {rebindAll} from '../../util/rebind';
 import {collisionArea} from './collision';
+import {identity} from '../../util/fn';
 
 // iteratively remove the rectangle with the greatest area of collision
-export default function() {
+export default function(adaptedStrategy) {
+
+    adaptedStrategy = adaptedStrategy || identity;
 
     var removeOverlaps = function(layout) {
+
+        layout = adaptedStrategy(layout);
 
         // returns a function that computes the area of overlap for rectangles
         // in the given layout array
@@ -29,6 +35,8 @@ export default function() {
 
         return layout;
     };
+
+    rebindAll(removeOverlaps, adaptedStrategy);
 
     return removeOverlaps;
 }


### PR DESCRIPTION
This fixes the issue I introduced in #924 - where I expected `removeOverlaps` to adapt other strategies. Which clearly it did not!

This is not an ideal solution - I'd prefer to be able to compose any number of strategies using a form of 'pipe'. However, there is some logic within the rectangles component that depends on the existence of properties on a strategy:

https://github.com/ScottLogic/d3fc/blob/master/src/layout/rectangles.js#L24

I'd rather not have to have a pipe that rebinds / combines properties.

I think this code needs further refactor, with the aim of making it more functional. Quite a few strategies have logic which handles out-of-bounds rectangles, this could be achieved by composing them with a strategy that is dedicated to this function.

Anyhow, for now - a quick fix. I'll have a think about a more fundamental refactor.