### PR TITLE
fix: axis tick text positioning in IE

### DIFF
--- a/src/fc.css
+++ b/src/fc.css
@@ -106,21 +106,12 @@ text {
   text-anchor: middle;
 }
 
-.tick.orient-left text,
-.tick.orient-right text {
-  dominant-baseline: middle;
-}
-
 .tick.orient-left text {
   text-anchor: end;
 }
 
 .tick.orient-right text {
   text-anchor: start;
-}
-
-.tick.orient-bottom text {
-  dominant-baseline: hanging;
 }
 
 /* Series Type Defaults */

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -123,6 +123,15 @@ export default function() {
 
             g.select('text')
                .attr('transform', translate(0, labelOffset))
+               .attr('dy', function() {
+                   var offset = '0em';
+                   if (isVertical()) {
+                       offset = '0.32em';
+                   } else if (orient === 'bottom') {
+                       offset = '0.71em';
+                   }
+                   return offset;
+               })
                .text(tickFormatter);
 
             // exit - for non ordinal scales, exit by animating the tick to its new location


### PR DESCRIPTION
Fixes #954.

This is a similar fix to that in #908 - using `dy` to align the text elements, rather than `dominant-baseline`. It's also consistent with how [D3's axis component positions the tick text elements](https://github.com/mbostock/d3/blob/c36befc7361cd61538294048c387a8a407b65dd1/src/svg/axis.js#L54-L62).

This is how it looks with the fix (see #954 to see the original problem):

| IE 11  | Chrome |
| ------------- | ------------- |
| ![axis-fixed-ie](https://cloud.githubusercontent.com/assets/2017615/14486227/afcc2aa4-0153-11e6-8504-63ba25868076.PNG) | ![axis-fixed-chrome](https://cloud.githubusercontent.com/assets/2017615/14486285/e4db43d8-0153-11e6-944d-e288aa0a7b6c.png) |