### PR TITLE
feat: Remove fc.version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -264,12 +264,6 @@ module.exports = function(grunt) {
             site: ['site/dist/*']
         },
 
-        version: {
-            defaults: {
-                src: ['dist/d3fc.js']
-            }
-        },
-
         less: {
             site: {
                 files: {
@@ -326,7 +320,7 @@ module.exports = function(grunt) {
     require('jit-grunt')(grunt);
 
     grunt.registerTask('components', [
-        'eslint:components', 'clean:components', 'rollup:components', 'version', 'concat:components',
+        'eslint:components', 'clean:components', 'rollup:components', 'concat:components',
         'concat_css:components', 'cssmin:components', 'eslint:test', 'jasmine_nodejs:test'
     ]);
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "grunt-rollup": "^0.6.2",
     "grunt-selenium-webdriver": "^0.2.451",
     "grunt-umd": "^2.3.3",
-    "grunt-version": "^1.0.0",
     "grunt-webdriver": "^1.0.0",
     "handlebars": "^4.0.5",
     "handlebars-helpers": "^0.5.8",

--- a/src/fc.js
+++ b/src/fc.js
@@ -10,9 +10,6 @@ import tool from './tool/tool';
 import util from './util/util';
 import layout from './layout/layout';
 
-// Needs to be defined like this so that the grunt task can update it
-var version = 'development';
-
 export default {
     annotation: annotation,
     chart: chart,
@@ -23,6 +20,5 @@ export default {
     svg: svg,
     tool: tool,
     util: util,
-    version: version,
     layout: layout
 };


### PR DESCRIPTION
It might be possible to write this information at js build time by running the pre script with a custom semantic-release plugin, but for now, removing it will simplify the move to using semantic-release.