### PR TITLE
fix: tooltip text alignment in IE

### DIFF
--- a/src/chart/tooltip.js
+++ b/src/chart/tooltip.js
@@ -38,9 +38,11 @@ export default function() {
 
             g.enter().append('text')
                 .attr('class', 'label')
+                .attr('dy', '0.71em')
                 .layout('flex', split);
             g.enter().append('text')
                 .attr('class', 'value')
+                .attr('dy', '0.71em')
                 .layout('flex', 100 - split);
 
             g.select('.label')

--- a/src/fc.css
+++ b/src/fc.css
@@ -48,10 +48,6 @@ text {
   border-collapse: separate;
 }
 
-.tooltip.cell {
-  dominant-baseline: hanging;
-}
-
 .plot-area {
   overflow: hidden;
 }


### PR DESCRIPTION
Fixes #977

This is a similar to the axis tick text alignment problem and solution (800bd27b969b9d15b285c2f91b537db8d9083ab1).