### PR TITLE
docs: fix cartesian chart extent example

### DIFF
--- a/site/src/components/introduction/cartesian-chart-extent.js
+++ b/site/src/components/introduction/cartesian-chart-extent.js
@@ -15,7 +15,7 @@ var data = generator(1).map(function(d, i) {
 
 //START
 var yExtent = fc.util.extent()
-    .include(0)
+    .include([0])
     .pad([0, 0.5])
     .fields(['sales']);
 


### PR DESCRIPTION
Looks like the functionality changed in issue 911.