### PR TITLE
Extent updates/fixes and eslint upgrade

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,12 @@
     "env": {
         "node": true
     },
+    "parserOptions": {
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "modules": true
+        }
+    },
     "rules": {
         "comma-dangle": 2,
         "no-cond-assign": 2,
@@ -44,7 +50,6 @@
         "no-caller": 2,
         "no-div-regex": 2,
         "no-else-return": 0,
-        "no-empty-label": 2,
         "no-eq-null": 0,
         "no-eval": 2,
         "no-extend-native": 2,
@@ -135,12 +140,11 @@
         "semi-spacing": 2,
         "semi": 2,
         "sort-vars": 0,
-        "space-after-keywords": 2,
+        "keyword-spacing": 2,
         "space-before-blocks": 2,
         "space-in-brackets": 0,
         "space-in-parens": 2,
         "space-infix-ops": 2,
-        "space-return-throw-case": 2,
         "space-unary-ops": 0,
         "spaced-line-comment": 0,
         "wrap-regex": 2,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "css-layout": "^1.1.0",
     "d3": "^3.5.4",
     "d3-svg-legend": "^1.9.0",
+    "d3fc-extent": "^2.2.0",
     "d3fc-financial-feed": "^1.0.0",
     "d3fc-label-layout": "^1.0.0",
     "d3fc-rebind": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "grunt-contrib-less": "^1.0.1",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-eslint": "^17.2.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-jasmine-node": "^0.3.1",
     "grunt-jasmine-nodejs": "^1.4.3",
     "grunt-rollup": "^0.6.2",

--- a/site/src/.eslintrc
+++ b/site/src/.eslintrc
@@ -13,6 +13,7 @@
         "no-spaced-func": 0,
         "no-multi-spaces": 0,
         "no-extend-native": 0,
-        "no-shadow": [2, {"builtinGlobals": false, "hoist": "all"}]
+        "no-shadow": [2, {"builtinGlobals": false, "hoist": "all"}],
+        "consistent-return": 0
     }
 }

--- a/site/src/components/util/extent.md
+++ b/site/src/components/util/extent.md
@@ -6,70 +6,33 @@ component: util/extent.js
 namespace: Util
 ---
 
- The extent function enhances the functionality of the equivalent D3 extent function, allowing you to pass an array of fields, or accessors, which will be used to derive the extent of the supplied array. For example, if you have an array of items with properties of 'high' and 'low', you can use `fc.util.extent().fields(['high', 'low'])(data)` to compute the extent of your data.
+Extends the D3 extent functionality (found in [d3-array](https://github.com/d3/d3-array)) to allow padding, multiple accessors and date support. Two variants are provided, one specialised for numeric values and another for dates -
 
 ```js
-  var data = [{low: 10, high: 30}, {low: 12, high: 40}];
-  var fields = ['high', 'low'];
+var data = [{ x: 1 }, { x: 2 }, { x: 4 }, { x: 8 }, { x: 16 }];
 
-  fc.util.extent().fields(fields)(data); // [10, 40]
+var extent = fc.util.extentLinear()
+  .accessors([function(d) { return d.x; }])
+  .pad([1, 4])
+  .padUnit('domain');
+
+extent(data);
+// [0, 20]
 ```
 
-A range can be symmetrical about a given value, using the `symmetricalAbout` property. Given a range of `[0, 5]` and specifying symmetry around `0` will yield a new range of `[-5, 5]`. This property has the highest precedence, i.e. it is performed before padding and including extra points.
+For more details on using linear extent see [d3fc-extent](https://github.com/d3fc/d3fc-extent#linear).
 
 ```js
-  fc.util.extent()
-      .fields(fields)
-      .symmetricalAbout(20); // [0, 40]
+var data = [{ x: new Date(2016, 0, 1) }, { x: new Date(2016, 0, 11) }];
+
+var extent = fc.util.extentDate()
+  .accessors([function(d) { return d.x; }])
+  .pad([0, 0.2]);
+
+extent(data);
+// [ 2016-01-01T00:00:00.000Z, 2016-01-13T00:00:00.000Z ]
 ```
 
- The range can be modified by using the `pad` property, and specifying a 'padUnit' to vary the type of padding required. The padUnit can be either 'domain' for padding the domain absolutely or 'percent' for padding by a percentage. It is set by default to 'percent'. Domain padding will increase the calculated range by the amount given. If the calculated range is `[10, 20]`, with padUnit set to 'domain', then the result of setting pad to '2' will be `[8, 22]`. `pad(0)` is an identity in both cases.
+For more details on using date extent see [d3fc-extent](https://github.com/d3fc/d3fc-extent#date).
 
-```js
-  fc.util.extent()
-      .fields(fields)
-      .padUnit('domain')
-      .pad(5)(data); // [5, 45]
-```
-
- Percentage padding will scale the calculated range by the given amount. If the calculated range is `[10, 20]`, then the result of setting pad to '1' will be `[5, 25]`. 
-
-```js
-  fc.util.extent()
-      .fields(fields)
-      .padUnit('percent')
-      .pad(0.5)(data); // [2.5, 47.5]
-```
-
- In addition, both padding properties support asymmetric padding.
-
-```js
-  fc.util.extent()
-      .fields(fields)
-      .padUnit('domain')
-      .pad([3, 5])(data); // [7, 45]
-  fc.util.extent()
-      .fields(fields)
-      .padUnit('percent')
-      .pad([0.25, 0.5])(data); // [2.5, 55]
-```
-
- The range can be extended to include an array of fixed values, using the `include` property. The range is extended after padding, so the order of setting the properties is not important. If the included values are already within the range there will be no change.
-
-```js
-  fc.util.extent()
-      .fields(fields)
-      .include([0])(data); // [0, 40]
-  fc.util.extent()
-      .fields(fields)
-      .pad(0.5)
-      .include([0, 50])(data); // [0, 50]
-```
-
-Extent can also be used on an array of arrays.
-
-```js
-  var data = [[{low: 2, high: 5}, {low: 1, high: 3}], [{low: 0, high: 6}]];
-  fc.util.extent().fields(['high', 'low'])(data); // [0, 6]  
-
-```
+Previously this functionality was provided by a single component but this resulted in unresolvable ambiguity. Whilst still available to ease upgrading, its use is deprecated and there are some [important changes](https://github.com/ScottLogic/d3fc/commit/00f3a9677803559f883fe673be11159a1bbe6c3f) to be aware of.

--- a/site/src/examples/multi-line/multi-line.js
+++ b/site/src/examples/multi-line/multi-line.js
@@ -84,7 +84,6 @@ var plotArea = fc.series.multi()
         default:
             return data;
         }
-        return this[index];
     });
 
 chart.plotArea(plotArea);

--- a/site/src/examples/stacked/stacked.js
+++ b/site/src/examples/stacked/stacked.js
@@ -12,7 +12,7 @@ d3.csv('https://d3fc.io/examples/stacked/data.csv', function(error, data) {
 
     var yExtent = fc.util.extent()
         .include(0)
-        .fields([function(d) { return d.y + d.y0; }]);
+        .fields([function(a) { return a.map(function(d) { return d.y + d.y0; }); }]);
 
     var legend = d3.legend.color()
       .orient('horizontal')

--- a/site/src/examples/streaming/streaming.js
+++ b/site/src/examples/streaming/streaming.js
@@ -13,16 +13,17 @@ function renderChart() {
 
     // Offset the range to include the full bar for the latest value
     var DAY_MS = 1000 * 60 * 60 * 24;
-    var xExtent = fc.util.extent()
-        .fields(['date'])
+    var xExtent = fc.util.extentDate()
+        .accessors([function(d) { return d.date; }])
         .padUnit('domain')
         .pad([DAY_MS * -bollingerAlgorithm.period()(data), DAY_MS]);
 
     // ensure y extent includes the bollinger bands
-    var yExtent = fc.util.extent().fields([
-        function(d) { return d.bollingerBands.upper; },
-        function(d) { return d.bollingerBands.lower; }
-    ]);
+    var yExtent = fc.util.extentLinear()
+        .accessors([
+            function(d) { return d.bollingerBands.upper; },
+            function(d) { return d.bollingerBands.lower; }
+        ]);
 
     // create a chart
     var chart = fc.chart.cartesian(

--- a/src/chart/sparkline.js
+++ b/src/chart/sparkline.js
@@ -55,6 +55,7 @@ export default function() {
                 case 1: return 'high';
                 case 2: return 'low';
                 case 3: return 'close';
+                default: throw new Error('Unexepected index');
                 }
             });
         });

--- a/src/series/algorithm/waterfall.js
+++ b/src/series/algorithm/waterfall.js
@@ -4,9 +4,7 @@ export default function() {
         yValue = function(d) { return d.y; },
         startsWithTotal = false,
         totals = function(d, i, data) {
-            if (i === data.length - 1) {
-                return 'Final';
-            }
+            return (i === data.length - 1) ? 'Final' : null;
         },
         directions = {
             up: 'up',

--- a/src/util/extent.js
+++ b/src/util/extent.js
@@ -22,7 +22,9 @@ export default function() {
             };
         });
 
+        // This is why we split out the date logic
         var peekedValue = data.length > 0 ? accessors[0](data[0]) : null;
+        peekedValue = Array.isArray(peekedValue) ? peekedValue[0] : peekedValue;
         var extent = Object.prototype.toString.call(peekedValue) === '[object Date]' ? dateExtent : linearExtent;
 
         return extent()

--- a/src/util/extent.js
+++ b/src/util/extent.js
@@ -1,9 +1,9 @@
-import { linearExtent, dateExtent } from 'd3fc-extent';
+import { extentLinear, extentDate } from 'd3fc-extent';
 
 export default function() {
 
     // eslint-disable-next-line
-    console.warn('fc.util.extent is deprecated, consider using fc.util.linearExtent/dateExtent');
+    console.warn('fc.util.extent is deprecated, consider using fc.util.extentLinear/extentDate');
 
     var fields = [],
         extraPoints = [],
@@ -25,7 +25,7 @@ export default function() {
         // This is why we split out the date logic
         var peekedValue = data.length > 0 ? accessors[0](data[0]) : null;
         peekedValue = Array.isArray(peekedValue) ? peekedValue[0] : peekedValue;
-        var extent = Object.prototype.toString.call(peekedValue) === '[object Date]' ? dateExtent : linearExtent;
+        var extent = Object.prototype.toString.call(peekedValue) === '[object Date]' ? extentDate : extentLinear;
 
         return extent()
             .accessors(accessors)

--- a/src/util/extent.js
+++ b/src/util/extent.js
@@ -27,10 +27,10 @@ export default function() {
             .include(extraPoints)
             .pad(
                 Array.isArray(pad) ? pad :
-                    [
-                        padUnit === 'percent' ? pad / 2 : pad,
-                        padUnit === 'percent' ? pad / 2 : pad
-                    ]
+                [
+                    padUnit === 'percent' ? pad / 2 : pad,
+                    padUnit === 'percent' ? pad / 2 : pad
+                ]
             )
             .padUnit(padUnit)
             .symmetricalAbout(symmetricalAbout)(data);

--- a/src/util/extent.js
+++ b/src/util/extent.js
@@ -2,6 +2,9 @@ import { linearExtent, dateExtent } from 'd3fc-extent';
 
 export default function() {
 
+    // eslint-disable-next-line
+    console.warn('fc.util.extent is deprecated, consider using fc.util.linearExtent/dateExtent');
+
     var fields = [],
         extraPoints = [],
         pad = 0,

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,6 +1,7 @@
 import dataJoin from './dataJoin';
 import expandRect from './expandRect';
 import extent from './extent';
+import { linearExtent, dateExtent } from 'd3fc-extent';
 import * as fn from './fn';
 import minimum from './minimum';
 import fractionalBarWidth from './fractionalBarWidth';
@@ -15,6 +16,8 @@ export default {
     dataJoin: dataJoin,
     expandRect: expandRect,
     extent: extent,
+    linearExtent: linearExtent,
+    dateExtent: dateExtent,
     fn: fn,
     minimum: minimum,
     fractionalBarWidth: fractionalBarWidth,

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,7 +1,7 @@
 import dataJoin from './dataJoin';
 import expandRect from './expandRect';
 import extent from './extent';
-import { linearExtent, dateExtent } from 'd3fc-extent';
+import { extentLinear, extentDate } from 'd3fc-extent';
 import * as fn from './fn';
 import minimum from './minimum';
 import fractionalBarWidth from './fractionalBarWidth';
@@ -16,8 +16,8 @@ export default {
     dataJoin: dataJoin,
     expandRect: expandRect,
     extent: extent,
-    linearExtent: linearExtent,
-    dateExtent: dateExtent,
+    extentLinear: extentLinear,
+    extentDate: extentDate,
     fn: fn,
     minimum: minimum,
     fractionalBarWidth: fractionalBarWidth,

--- a/tests/series/waterfallSpec.js
+++ b/tests/series/waterfallSpec.js
@@ -98,9 +98,7 @@ describe('waterfall algorithm', function() {
     it('should insert totals', function() {
         var waterfallData = algorithm
             .total(function(d, i, inputData) {
-                if ((i + 1) % 3 === 0) {
-                    return 'Q' + ((i + 1) / 3) + ' total';
-                }
+                return ((i + 1) % 3 === 0) ? 'Q' + ((i + 1) / 3) + ' total' : null;
             })(data);
 
         var expectedData = [

--- a/tests/util/extentSpec.js
+++ b/tests/util/extentSpec.js
@@ -323,6 +323,17 @@ describe('fc.util.extent', function() {
         expect(extents).toEqual([-10, 40]);
     });
 
+    it('should support arrays of arrays of dates', function() {
+        var data = [{ date: new Date(2014, 0, 10) }, { date: new Date(2014, 0, 20) }];
+        var data2 = [{ date: new Date(2014, 0, 20) }, { date: new Date(2014, 0, 30) }];
+
+        var extents = fc.util.extent()
+            .fields(
+                [function(a) { return a.map(function(d) { return d.date; }); }]
+            )([data, data2]);
+        expect(extents).toEqual([new Date(2014, 0, 10), new Date(2014, 0, 30)]);
+    });
+
     it('should pad dates symmetrically with domain padding', function() {
         var date1 = new Date(2014, 0, 10);
         var date2 = new Date(2014, 0, 20);

--- a/visual-tests/.eslintrc
+++ b/visual-tests/.eslintrc
@@ -13,6 +13,7 @@
         "no-spaced-func": 0,
         "no-multi-spaces": 0,
         "no-extend-native": 0,
-        "no-shadow": [2, {"builtinGlobals": false, "hoist": "all"}]
+        "no-shadow": [2, {"builtinGlobals": false, "hoist": "all"}],
+        "consistent-return": 0
     }
 }

--- a/visual-tests/series/waterfall.js
+++ b/visual-tests/series/waterfall.js
@@ -29,9 +29,7 @@
             .yValue(function(d) { return d.profit; })
             .startsWithTotal(true)
             .total(function(d, i) {
-                if ((i + 1) % 3 === 0) {
-                    return 'Q' + ((i + 1) / 3) + ' total';
-                }
+                return ((i + 1) % 3 === 0) ? 'Q' + ((i + 1) / 3) + ' total' : null;
             })(data);
 
         // Create scale for x axis

--- a/webdriver-tests/siteConsoleSpec.js
+++ b/webdriver-tests/siteConsoleSpec.js
@@ -13,7 +13,8 @@ describe('Visit all pages, check for no console errors', function() {
                     .then(function(result) {
                         result.value.filter(function(e) {
                             return e.message.indexOf('livereload') === -1 //Excluding liverload errors
-                                && e.message.indexOf('https://www.quandl.com/api/v3/') === -1; // Excluding Quandl API Issues (limited number of requests per day)
+                                && e.message.indexOf('https://www.quandl.com/api/v3/') === -1 // Excluding Quandl API Issues (limited number of requests per day)
+                                && e.message.indexOf('fc.util.extent is deprecated') === -1; // Exclude fc.util.extent deprecation warnings
                         }).forEach(function(e) {
                             expect(e).toBeUndefined('Errors/console logs in the url: ' + url);
                         });


### PR DESCRIPTION
Deprecates `fc.util.extent` and warns if used.