### PR TITLE
docs: fix grouped bar example

### DIFF
--- a/site/src/components/series/grouped-example.js
+++ b/site/src/components/series/grouped-example.js
@@ -49,7 +49,11 @@ var x = d3.scale.ordinal()
     .rangePoints([0, width], 1);
 
 var yExtent = fc.util.extent()
-    .fields(['y'])
+    .fields([
+        function(a) {
+            return a.map(function(d) { return d.y; });
+        }
+    ])
     .include(0);
 
 var y = d3.scale.linear()


### PR DESCRIPTION
Caused by extent changes no longer recursing in to nested arrays 

https://github.com/ScottLogic/d3fc/releases/tag/v11.0.0

Fixes #1013